### PR TITLE
fix: update vault requirement messaging for clarity

### DIFF
--- a/pages/side-panel/src/components/Connect.tsx
+++ b/pages/side-panel/src/components/Connect.tsx
@@ -57,7 +57,7 @@ const Connect: React.FC<ConnectProps> = ({ setIsConnecting }) => {
       if (window) {
         setTimeout(() => {
           window.location.assign('keepkey://launch');
-          window.open('https://keepkey.com/launch', '_blank');
+          window.open('https://keepkey.com/get-started', '_blank');
         }, 100); // Adding a slight delay before launching the URL
       }
     } catch (error) {
@@ -77,24 +77,28 @@ const Connect: React.FC<ConnectProps> = ({ setIsConnecting }) => {
         textAlign="center"
         boxShadow="lg">
         <Image src={'https://i.ibb.co/jR8WcJM/kk.gif'} alt="KeepKey" />
-        <Text fontSize="lg" mb={4}>
-          Plug in your KeepKey to get started...
+        <Text fontSize="lg" fontWeight="bold" mb={2}>
+          KeepKey Vault Required
+        </Text>
+        <Text fontSize="sm" mb={4} color="gray.500">
+          The KeepKey Vault desktop app must be running to use this extension.
         </Text>
         <Stack direction="column" spacing={4} mb={4}>
           <Button colorScheme="blue" onClick={launchKeepKey}>
-            Launch KeepKey Desktop
+            Launch KeepKey Vault
           </Button>
 
-          <br />
-          <h3>Already running?</h3>
+          <Text fontSize="xs" color="gray.400">
+            Already running?
+          </Text>
           <Button colorScheme="teal" onClick={connectKeepkey}>
-            Connect to your KeepKey
+            Retry Connection
           </Button>
         </Stack>
         <Text fontSize="sm" mt={4}>
-          Dont have a KeepKey?{' '}
+          Don't have KeepKey Vault?{' '}
           <Button variant="link" color="teal.500" onClick={openKeepKeyLink}>
-            Buy a KeepKey
+            Download at keepkey.com
           </Button>
         </Text>
       </Card>

--- a/pages/side-panel/src/components/Loading.tsx
+++ b/pages/side-panel/src/components/Loading.tsx
@@ -30,7 +30,7 @@ const Loading: React.FC<ConnectProps> = ({ setIsConnecting, keepkeyState }) => {
         <Box textAlign="center">
           <h2>Status: {keepkeyState}</h2>
           <Spinner size="6xl" />
-          <Text mt={4}>Connecting to KeepKey...</Text>
+          <Text mt={4}>Connecting to KeepKey Vault...</Text>
         </Box>
       </Card>
     </Box>


### PR DESCRIPTION
## Summary
- Replaced vague "Plug in your KeepKey" with clear **"KeepKey Vault Required"** heading and subtitle explaining the desktop app must be running
- Updated all button labels: "Launch KeepKey Vault", "Retry Connection", "Download at keepkey.com"
- Loading screen now says "Connecting to KeepKey Vault..."

## Test plan
- [ ] Open side panel with vault NOT running — verify "KeepKey Vault Required" message and subtitle
- [ ] Click "Launch KeepKey Vault" — verify keepkey:// protocol handler fires
- [ ] Click "Retry Connection" — verify it attempts reconnection
- [ ] Open side panel with vault running — verify "Connecting to KeepKey Vault..." loading text

🤖 Generated with [Claude Code](https://claude.com/claude-code)