### PR TITLE
fix: respect forceRefresh in balance fetch deduplication

### DIFF
--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -103,7 +103,7 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
   // Deduplicate concurrent calls — but honor forceRefresh
   if (balancesFetchInProgress && !forceRefresh) return balancesFetchInProgress;
 
-  balancesFetchInProgress = (async () => {
+  const thisPromise: Promise<any[]> = (async () => {
     try {
       const allPubkeys = wallet.getPubkeys();
       if (allPubkeys.length === 0) return cachedBalances;
@@ -301,11 +301,16 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
       console.error('[fetchBalances] Error:', e.message || e);
       return cachedBalances;
     } finally {
-      balancesFetchInProgress = null;
+      // Only clear the in-flight ref if it still points to this promise — a newer
+      // forceRefresh call may have replaced it while we were running.
+      if (balancesFetchInProgress === thisPromise) {
+        balancesFetchInProgress = null;
+      }
     }
   })();
 
-  return balancesFetchInProgress;
+  balancesFetchInProgress = thisPromise;
+  return thisPromise;
 }
 
 const onStart = async function () {

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -100,8 +100,8 @@ let balancesFetchInProgress: Promise<any[]> | null = null;
 const EVM_CAIPS = [...new Set(Object.values(shortListSymbolToCaip).filter(caip => caip.startsWith('eip155:')))];
 
 async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
-  // Deduplicate concurrent calls
-  if (balancesFetchInProgress) return balancesFetchInProgress;
+  // Deduplicate concurrent calls — but honor forceRefresh
+  if (balancesFetchInProgress && !forceRefresh) return balancesFetchInProgress;
 
   balancesFetchInProgress = (async () => {
     try {


### PR DESCRIPTION
## Summary
- `fetchBalancesFromPioneer(forceRefresh=true)` no longer returns stale in-progress promise
- Dedup check is skipped when force refresh is explicitly requested

## Test plan
- [ ] Trigger manual balance refresh, verify it fetches new data even if a fetch was in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)