### PR TITLE
fix: lazy-load storage cache on set() to prevent null spread

### DIFF
--- a/packages/storage/lib/base.ts
+++ b/packages/storage/lib/base.ts
@@ -168,6 +168,9 @@ export function createStorage<D = string>(key: string, fallback: D, config?: Sto
   };
 
   const set = async (valueOrUpdate: ValueOrUpdate<D>) => {
+    if (cache === null) {
+      cache = await _getDataFromStorage();
+    }
     cache = await updateCache(valueOrUpdate, cache);
 
     await chrome.storage[storageType].set({ [key]: serialize(cache) });


### PR DESCRIPTION
## Summary
- Fixes `TypeError: a is not iterable` thrown from `customStorage.addEvent` (and any other storage updater that spreads `prev`) when the MV3 service worker wakes up and calls `set(...)` before the async initial load of `cache` resolves.
- Observed in the wild on `eth_signTypedData_v4`: `requestStorage.addEvent` failed, but the ethereum handler continued to `requireApproval(...)` anyway — popup opened for a request that was never persisted, and the signing flow hung in a bad state.

## Root cause
`packages/storage/lib/base.ts` initializes `cache` to `null` and populates it via a fire-and-forget `_getDataFromStorage().then(...)`. In MV3 service workers that get torn down frequently, `set()` can be called before that promise resolves. The updater then runs with `prev = null`, and `[...null, event]` throws.

## Fix
In `set()`, if `cache === null`, await `_getDataFromStorage()` first so the updater always receives a real value (the on-disk value or the configured fallback).

## Test plan
- [ ] Reload extension, trigger `eth_signTypedData_v4` on a dapp, confirm the approval popup shows the request (no `TypeError` in background console).
- [ ] Confirm `eth_sendTransaction` / `personal_sign` flows still populate `requestStorage` → approval → completed.
- [ ] Confirm cold-start (kill service worker, reissue a request immediately) no longer drops the first event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)