### PR TITLE
fix(side-panel): receive tab loads offline + auto token discovery

### DIFF
--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -19,6 +19,9 @@
   "dependencies": {
     "@extension/shared": "workspace:*",
     "@extension/storage": "workspace:*",
+    "@noble/hashes": "^1.5.0",
+    "@scure/base": "^1.1.9",
+    "@scure/bip32": "^1.5.0",
     "buffer": "^6.0.3",
     "ethers": "^6.13.2",
     "keepkey-vault-sdk": "^3.0.1",

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -916,6 +916,23 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
                 if (!asset.address && asset.pubkeys?.[0]?.address) {
                   asset.address = asset.pubkeys[0].address;
                 }
+
+                // UTXO assets coming from non-header paths (global
+                // Receive, dashboard balance click, asset list) don't
+                // carry a specific note/script_type. Without one,
+                // GET_PUBKEY_CONTEXT falls back to scoped[0] — usually
+                // legacy BTC — and Receive shows a "1..." address while
+                // the header still reads "Native SegWit". Default to
+                // first p2wpkh (Native Segwit) on the network, then any
+                // scoped[0], so all entry points agree.
+                if (asset.networkId.startsWith('bip122:') && !asset.note && !asset.script_type) {
+                  const scoped = wallet.getPubkeys(asset.networkId);
+                  const preferred = scoped.find((pk: any) => pk.script_type === 'p2wpkh') || scoped[0];
+                  if (preferred) {
+                    asset.note = preferred.note;
+                    asset.script_type = preferred.script_type;
+                  }
+                }
               }
 
               // Enrich asset with cached native balance so Send/Transfer can

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -7,6 +7,7 @@ globalThis.Buffer = Buffer;
 
 import packageJson from '../../package.json';
 import * as wallet from './wallet';
+import { deriveUtxoAddress } from './utxoDerive';
 import { resetSolanaState, prefetchSolanaPubkey } from './chains/solanaHandler';
 import { resetTonState, prefetchTonAddress } from './chains/tonHandler';
 import { resetTronState, prefetchTronPubkey } from './chains/tronHandler';
@@ -672,32 +673,31 @@ const onStart = async function () {
       }
 
       // Fetch balances in background (non-blocking). First pass covers EVM/UTXO
-      // quickly — on first run the Solana pubkey hasn't been derived yet, so it
-      // won't be in this request.
+      // quickly — on first run the Solana / Tron / TON pubkeys haven't been
+      // derived yet, so they won't be in this request.
       fetchBalancesFromPioneer().catch(e => console.warn(tag, 'Initial balance fetch failed:', e));
 
-      // Prefetch Solana pubkey so it shows up in the network dropdown. Once the
-      // pubkey is registered, force a second balance fetch so Solana natives +
-      // SPL tokens land in cachedBalances (fixes first-run race).
-      prefetchSolanaPubkey()
+      // Solana / Tron / TON addresses are derived outside the batch xpub
+      // flow (firmware message type is separate). Each prefetch internally
+      // calls wallet.addPubkey, so once they all settle the wallet has the
+      // complete pubkey set. We then fire ONE force-refresh against Pioneer
+      // /portfolio with everyone present — that's the request whose
+      // snapshot won't be invalidated mid-flight, so its commit actually
+      // lands.
+      //
+      // Why not chain a force-fetch after each individual prefetch (the
+      // old shape)? Because they ran in parallel: each fetch's snapshot
+      // misses the pubkeys still being added by the other two prefetches,
+      // and the staleness guard at fetchBalancesFromPioneer's commit step
+      // discards them. With three parallel prefetches, only the last one
+      // to commit could survive — and if that one was Tron/TON without
+      // Solana having fully landed yet, SPL tokens never made it into
+      // cachedBalances. Users saw "No tokens" until they hit the manual
+      // Discover button (which by coincidence runs after the slowest
+      // prefetch finally lands).
+      Promise.allSettled([prefetchSolanaPubkey(), prefetchTronPubkey(), prefetchTonAddress()])
         .then(() => fetchBalancesFromPioneer(true))
-        .catch(() => {});
-
-      // Same race for Tron — firmware message type is separate from the batch
-      // xpub flow, so we derive lazily and force a refetch once the pubkey is
-      // cached. Balance lookup goes through the dedicated /tron/accountInfo
-      // endpoint inside fetchBalancesFromPioneer (TronGrid coverage).
-      prefetchTronPubkey()
-        .then(() => fetchBalancesFromPioneer(true))
-        .catch(() => {});
-
-      // Same story for TON — address is derived via /addresses/ton, not
-      // the xpub batch. Prefetch so the network shows up in the dropdown
-      // and trigger a rebalance once the TON pubkey is cached so the
-      // nanoTON → TON native balance lands.
-      prefetchTonAddress()
-        .then(() => fetchBalancesFromPioneer(true))
-        .catch(() => {});
+        .catch(e => console.warn(tag, 'Post-prefetch balance fetch failed:', e));
     } else {
       console.error(tag, 'FAILED TO INIT, No Ethereum address found');
     }
@@ -1102,6 +1102,60 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
           const { networkId } = message;
           const pubkeys = wallet.getPubkeys(networkId);
           sendResponse({ pubkeys });
+          break;
+        }
+
+        // Derive a UTXO receive address locally from the xpub held in the
+        // matching pubkey entry. Needed because /api/pubkeys/batch returns
+        // UTXO rows with { pubkey: "<xpub>", address: "" } — showing the
+        // xpub as an address was the endless-spinner / wrong-address bug on
+        // the Receive page. Pubkey-to-address is pure BIP32 + script-type
+        // encoding, so no device round-trip is required; this works in
+        // view-only mode too. Cached per (networkId, scriptType, note).
+        case 'GET_UTXO_ADDRESS': {
+          const { networkId, scriptType, note } = message as {
+            networkId: string;
+            scriptType?: string;
+            note?: string;
+          };
+          try {
+            const scoped = wallet.getPubkeys(networkId);
+            if (scoped.length === 0) {
+              sendResponse({ error: 'No pubkey for network' });
+              break;
+            }
+            // `note` is unique per path config, so match it first — multiple
+            // accounts can share a scriptType (e.g. several BTC p2wpkh
+            // accounts), and matching scriptType first would always pick the
+            // first one regardless of which account the caller asked for.
+            const match =
+              (note && scoped.find((pk: any) => pk.note === note)) ||
+              (scriptType && scoped.find((pk: any) => pk.scriptType === scriptType)) ||
+              scoped[0];
+            const cacheKey = `utxoaddr:${networkId}:${match.scriptType || ''}:${match.note || ''}`;
+            const cached = await chrome.storage.session.get(cacheKey).catch(() => ({}) as any);
+            if (cached[cacheKey]) {
+              sendResponse({ address: cached[cacheKey], scriptType: match.scriptType });
+              break;
+            }
+            const xpub: string | undefined = match.pubkey || match.master;
+            if (!xpub) {
+              sendResponse({ error: 'No xpub on pubkey entry' });
+              break;
+            }
+            const address = deriveUtxoAddress({
+              xpub,
+              scriptType: match.scriptType,
+              networkId,
+            });
+            if (address) {
+              void chrome.storage.session.set({ [cacheKey]: address }).catch(() => {});
+            }
+            sendResponse({ address, scriptType: match.scriptType });
+          } catch (e: any) {
+            console.error('GET_UTXO_ADDRESS failed:', e);
+            sendResponse({ error: e?.message || 'deriveUtxoAddress failed' });
+          }
           break;
         }
 

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -1111,7 +1111,9 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
         // xpub as an address was the endless-spinner / wrong-address bug on
         // the Receive page. Pubkey-to-address is pure BIP32 + script-type
         // encoding, so no device round-trip is required; this works in
-        // view-only mode too. Cached per (networkId, scriptType, note).
+        // view-only mode too. Not cached: derivation is microseconds, and
+        // a session-storage cache keyed without the xpub would surface the
+        // previous device's address after a hot-swap.
         case 'GET_UTXO_ADDRESS': {
           const { networkId, scriptType, note } = message as {
             networkId: string;
@@ -1124,20 +1126,17 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
               sendResponse({ error: 'No pubkey for network' });
               break;
             }
-            // `note` is unique per path config, so match it first — multiple
-            // accounts can share a scriptType (e.g. several BTC p2wpkh
-            // accounts), and matching scriptType first would always pick the
-            // first one regardless of which account the caller asked for.
+            // `note` is unique per path config, so match it first —
+            // multiple accounts can share a script_type (e.g. several BTC
+            // p2wpkh accounts), and matching by script_type first would
+            // always pick the first one regardless of which account the
+            // caller asked for. Raw pubkey objects use snake_case
+            // `script_type`, matching chainConfig.ts and the SDK request
+            // shape; do not rename them here.
             const match =
               (note && scoped.find((pk: any) => pk.note === note)) ||
-              (scriptType && scoped.find((pk: any) => pk.scriptType === scriptType)) ||
+              (scriptType && scoped.find((pk: any) => pk.script_type === scriptType)) ||
               scoped[0];
-            const cacheKey = `utxoaddr:${networkId}:${match.scriptType || ''}:${match.note || ''}`;
-            const cached = await chrome.storage.session.get(cacheKey).catch(() => ({}) as any);
-            if (cached[cacheKey]) {
-              sendResponse({ address: cached[cacheKey], scriptType: match.scriptType });
-              break;
-            }
             const xpub: string | undefined = match.pubkey || match.master;
             if (!xpub) {
               sendResponse({ error: 'No xpub on pubkey entry' });
@@ -1145,13 +1144,10 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
             }
             const address = deriveUtxoAddress({
               xpub,
-              scriptType: match.scriptType,
+              scriptType: match.script_type,
               networkId,
             });
-            if (address) {
-              void chrome.storage.session.set({ [cacheKey]: address }).catch(() => {});
-            }
-            sendResponse({ address, scriptType: match.scriptType });
+            sendResponse({ address, scriptType: match.script_type });
           } catch (e: any) {
             console.error('GET_UTXO_ADDRESS failed:', e);
             sendResponse({ error: e?.message || 'deriveUtxoAddress failed' });

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -920,14 +920,26 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
                 // UTXO assets coming from non-header paths (global
                 // Receive, dashboard balance click, asset list) don't
                 // carry a specific note/script_type. Without one,
-                // GET_PUBKEY_CONTEXT falls back to scoped[0] — usually
-                // legacy BTC — and Receive shows a "1..." address while
-                // the header still reads "Native SegWit". Default to
-                // first p2wpkh (Native Segwit) on the network, then any
-                // scoped[0], so all entry points agree.
+                // GET_PUBKEY_CONTEXT falls back to scoped[0] and
+                // Receive shows a different address from what the
+                // header dropdown displays.
+                //
+                // Default selection mirrors what the header builders do
+                // so all entry points stay in sync:
+                //   - BTC: first p2wpkh (buildBtcAccounts marks Native
+                //     Segwit as isDefault).
+                //   - Other UTXO (LTC, DOGE, DASH, BCH): first scoped
+                //     pubkey in chainConfig order — buildUtxoAccounts
+                //     uses items.length === 0, so e.g. LTC defaults to
+                //     legacy p2pkh (configured before p2wpkh) and we
+                //     must NOT silently shift it to native segwit.
+                const BTC_GENESIS_PREFIX = 'bip122:000000000019d6689c085ae165831e93';
                 if (asset.networkId.startsWith('bip122:') && !asset.note && !asset.script_type) {
                   const scoped = wallet.getPubkeys(asset.networkId);
-                  const preferred = scoped.find((pk: any) => pk.script_type === 'p2wpkh') || scoped[0];
+                  const isBtc = asset.networkId.startsWith(BTC_GENESIS_PREFIX);
+                  const preferred = isBtc
+                    ? scoped.find((pk: any) => pk.script_type === 'p2wpkh') || scoped[0]
+                    : scoped[0];
                   if (preferred) {
                     asset.note = preferred.note;
                     asset.script_type = preferred.script_type;

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -1059,13 +1059,20 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
             if (ctx?.networkId) {
               const scoped = wallet.getPubkeys(ctx.networkId);
               if (scoped.length > 0) {
-                // Prefer a pubkey whose accountIndex matches the ctx (asset
-                // carries accountIndex when the UI drilled into a non-default
-                // account); otherwise the first match on this network.
-                chosen =
-                  (ctx as any).accountIndex !== undefined
-                    ? scoped.find((pk: any) => pk.accountIndex === (ctx as any).accountIndex)
-                    : null;
+                // UTXO accounts share an accountIndex (BTC has Legacy /
+                // Segwit / Native Segwit all at account 0); script_type is
+                // what distinguishes them, so check it first. The header
+                // sets ctx.script_type when the user picks an account in
+                // the UTXO dropdown.
+                const ctxScriptType = (ctx as any).script_type;
+                if (ctxScriptType) {
+                  chosen = scoped.find((pk: any) => pk.script_type === ctxScriptType);
+                }
+                // Fall through to accountIndex matching (multi-account EVM)
+                // and finally scoped[0].
+                if (!chosen && (ctx as any).accountIndex !== undefined) {
+                  chosen = scoped.find((pk: any) => pk.accountIndex === (ctx as any).accountIndex);
+                }
                 if (!chosen) chosen = scoped[0];
               }
             }

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -1059,17 +1059,20 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
             if (ctx?.networkId) {
               const scoped = wallet.getPubkeys(ctx.networkId);
               if (scoped.length > 0) {
-                // UTXO accounts share an accountIndex (BTC has Legacy /
-                // Segwit / Native Segwit all at account 0); script_type is
-                // what distinguishes them, so check it first. The header
-                // sets ctx.script_type when the user picks an account in
-                // the UTXO dropdown.
+                // Match priority: note → script_type → accountIndex →
+                // scoped[0]. Note is the only identifier that's unique
+                // across every chainConfig path; script_type collapses
+                // BTC account 0 / account 1 (both p2wpkh) and would
+                // always pick the first one. accountIndex is fine for
+                // multi-account EVM but is unset on UTXO header rows.
+                const ctxNote = (ctx as any).note;
                 const ctxScriptType = (ctx as any).script_type;
-                if (ctxScriptType) {
+                if (ctxNote) {
+                  chosen = scoped.find((pk: any) => pk.note === ctxNote);
+                }
+                if (!chosen && ctxScriptType) {
                   chosen = scoped.find((pk: any) => pk.script_type === ctxScriptType);
                 }
-                // Fall through to accountIndex matching (multi-account EVM)
-                // and finally scoped[0].
                 if (!chosen && (ctx as any).accountIndex !== undefined) {
                   chosen = scoped.find((pk: any) => pk.accountIndex === (ctx as any).accountIndex);
                 }

--- a/chrome-extension/src/background/utxoDerive.ts
+++ b/chrome-extension/src/background/utxoDerive.ts
@@ -1,0 +1,194 @@
+/**
+ * Local UTXO receive-address derivation from an extended pubkey.
+ *
+ * Replaces the old GET_UTXO_ADDRESS round-trip to the device — pubkey →
+ * address is pure BIP32 + script-type encoding, no signing involved, so
+ * the device isn't needed. Lets the Receive page render even in
+ * view-only mode (cached pubkeys, no device attached).
+ */
+import { HDKey } from '@scure/bip32';
+import { base58check, bech32 } from '@scure/base';
+import { sha256 } from '@noble/hashes/sha2';
+import { ripemd160 } from '@noble/hashes/legacy';
+
+const bs58check = base58check(sha256);
+
+interface CoinParams {
+  p2pkhVersion: number;
+  p2shVersion: number;
+  bech32Hrp?: string;
+  cashaddrPrefix?: string;
+}
+
+// Keyed by the `chain` portion of the bip122 networkId (block hash of genesis).
+const COIN_BY_GENESIS: Record<string, CoinParams> = {
+  // Bitcoin
+  '000000000019d6689c085ae165831e93': { p2pkhVersion: 0x00, p2shVersion: 0x05, bech32Hrp: 'bc' },
+  // Bitcoin Cash
+  '000000000000000000651ef99cb9fcbe': { p2pkhVersion: 0x00, p2shVersion: 0x05, cashaddrPrefix: 'bitcoincash' },
+  // Litecoin
+  '12a765e31ffd4059bada1e25190f6e98': { p2pkhVersion: 0x30, p2shVersion: 0x32, bech32Hrp: 'ltc' },
+  // Dogecoin
+  '00000000001a91e3dace36e2be3bf030': { p2pkhVersion: 0x1e, p2shVersion: 0x16 },
+  // Dash
+  '000007d91d1254d60e2dd1ae58038307': { p2pkhVersion: 0x4c, p2shVersion: 0x10 },
+};
+
+function paramsForNetwork(networkId: string): CoinParams {
+  // bip122:<genesis>/slip44:<n>
+  const m = /^bip122:([0-9a-f]+)/i.exec(networkId);
+  const genesis = m?.[1];
+  const params = genesis ? COIN_BY_GENESIS[genesis] : undefined;
+  if (!params) throw new Error(`Unsupported UTXO networkId: ${networkId}`);
+  return params;
+}
+
+function hash160(pubkey: Uint8Array): Uint8Array {
+  return ripemd160(sha256(pubkey));
+}
+
+// @scure/bip32 only parses the canonical xpub version (0x0488B21E). Vault
+// returns ypub/zpub/Ltub/Mtub for BIP49/84 paths — same payload, different
+// version bytes. Rewrite to xpub bytes so HDKey can parse, then derive.
+const XPUB_VERSION = Uint8Array.from([0x04, 0x88, 0xb2, 0x1e]);
+
+function normalizeToXpub(extKey: string): string {
+  const decoded = bs58check.decode(extKey);
+  if (decoded.length !== 78) throw new Error(`Invalid extended key length: ${decoded.length}`);
+  decoded.set(XPUB_VERSION, 0);
+  return bs58check.encode(decoded);
+}
+
+function deriveReceiveChildPubkey(extKey: string): Uint8Array {
+  const hd = HDKey.fromExtendedKey(normalizeToXpub(extKey));
+  const child = hd.derive('m/0/0');
+  if (!child.publicKey) throw new Error('Derivation produced no public key');
+  return child.publicKey;
+}
+
+function encodeP2PKH(pubkey: Uint8Array, version: number): string {
+  const payload = new Uint8Array(21);
+  payload[0] = version;
+  payload.set(hash160(pubkey), 1);
+  return bs58check.encode(payload);
+}
+
+function encodeP2SHP2WPKH(pubkey: Uint8Array, p2shVersion: number): string {
+  // redeemScript = OP_0 <0x14> <hash160(pubkey)>
+  const h = hash160(pubkey);
+  const redeem = new Uint8Array(22);
+  redeem[0] = 0x00;
+  redeem[1] = 0x14;
+  redeem.set(h, 2);
+  const payload = new Uint8Array(21);
+  payload[0] = p2shVersion;
+  payload.set(hash160(redeem), 1);
+  return bs58check.encode(payload);
+}
+
+function encodeP2WPKH(pubkey: Uint8Array, hrp: string): string {
+  const program = hash160(pubkey);
+  const words = bech32.toWords(program);
+  return bech32.encode(hrp, [0, ...words], 90);
+}
+
+// CashAddr — BCH's bech32-variant address format.
+// Spec: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md
+const CASHADDR_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+const CASHADDR_GENERATORS: bigint[] = [
+  BigInt('0x98f2bc8e61'),
+  BigInt('0x79b76d99e2'),
+  BigInt('0xf33e5fb3c4'),
+  BigInt('0xae2eabe2a8'),
+  BigInt('0x1e4f43e470'),
+];
+
+const ONE = BigInt(1);
+const SHIFT_5 = BigInt(5);
+const SHIFT_35 = BigInt(35);
+const MASK_35 = BigInt('0x07ffffffff');
+
+function cashaddrPolymod(values: number[]): bigint {
+  let chk = ONE;
+  for (const v of values) {
+    const top = chk >> SHIFT_35;
+    chk = ((chk & MASK_35) << SHIFT_5) ^ BigInt(v);
+    for (let i = 0; i < 5; i++) {
+      if (((top >> BigInt(i)) & ONE) === ONE) chk ^= CASHADDR_GENERATORS[i];
+    }
+  }
+  return chk ^ ONE;
+}
+
+function cashaddrPrefixToValues(prefix: string): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < prefix.length; i++) out.push(prefix.charCodeAt(i) & 0x1f);
+  return out;
+}
+
+function cashaddrConvertBits(data: Uint8Array | number[], from: number, to: number, pad: boolean): number[] {
+  let acc = 0;
+  let bits = 0;
+  const out: number[] = [];
+  const maxv = (1 << to) - 1;
+  for (const value of data) {
+    if (value < 0 || value >> from !== 0) throw new Error('Invalid value for convertBits');
+    acc = (acc << from) | value;
+    bits += from;
+    while (bits >= to) {
+      bits -= to;
+      out.push((acc >> bits) & maxv);
+    }
+  }
+  if (pad && bits > 0) out.push((acc << (to - bits)) & maxv);
+  return out;
+}
+
+function encodeCashAddr(pubkey: Uint8Array, prefix: string): string {
+  const h = hash160(pubkey);
+  // P2KH = type 0; size bits for 20-byte hash = 0
+  const versionByte = (0 << 3) | 0;
+  const payload = [versionByte, ...h];
+  const data = cashaddrConvertBits(payload, 8, 5, true);
+  const checksumValues = [...cashaddrPrefixToValues(prefix), 0, ...data, 0, 0, 0, 0, 0, 0, 0, 0];
+  const checksum = cashaddrPolymod(checksumValues);
+  const checksumChars: number[] = [];
+  const MASK_5 = BigInt(0x1f);
+  for (let i = 0; i < 8; i++) {
+    checksumChars.push(Number((checksum >> BigInt(5 * (7 - i))) & MASK_5));
+  }
+  let body = '';
+  for (const v of [...data, ...checksumChars]) body += CASHADDR_CHARSET[v];
+  return `${prefix}:${body}`;
+}
+
+export interface DeriveArgs {
+  xpub: string;
+  scriptType?: string;
+  networkId: string;
+}
+
+export function deriveUtxoAddress({ xpub, scriptType, networkId }: DeriveArgs): string {
+  const params = paramsForNetwork(networkId);
+  const pubkey = deriveReceiveChildPubkey(xpub);
+
+  // BCH always returns cashaddr — keepkey firmware does the same, and a
+  // base58 "1..." legacy BCH address looks like a BTC address to users.
+  if (params.cashaddrPrefix) {
+    return encodeCashAddr(pubkey, params.cashaddrPrefix);
+  }
+
+  const st = (scriptType || 'p2pkh').toLowerCase();
+  switch (st) {
+    case 'p2pkh':
+      return encodeP2PKH(pubkey, params.p2pkhVersion);
+    case 'p2sh-p2wpkh':
+      return encodeP2SHP2WPKH(pubkey, params.p2shVersion);
+    case 'p2wpkh': {
+      if (!params.bech32Hrp) throw new Error(`No bech32 HRP for network ${networkId}`);
+      return encodeP2WPKH(pubkey, params.bech32Hrp);
+    }
+    default:
+      throw new Error(`Unsupported script type: ${scriptType}`);
+  }
+}

--- a/pages/side-panel/index.html
+++ b/pages/side-panel/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <title>Side Panel</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet" />
   </head>
 
   <body>

--- a/pages/side-panel/src/SidePanel.tsx
+++ b/pages/side-panel/src/SidePanel.tsx
@@ -232,8 +232,15 @@ const SidePanel = () => {
           icon: ctx.icon || '',
           address: ctx.address || '',
         };
+        // Update the selected-asset state so an already-open drawer
+        // reflects the new context, but DON'T auto-open. This listener
+        // fires on every SET_ASSET_CONTEXT — including our own header
+        // auto-default sync on cold start and dApp-triggered chain
+        // switches — and users shouldn't have a drawer surface
+        // unprompted. Explicit opens go through handleAssetSelect
+        // (asset list / header click), which both setSelectedAsset
+        // AND onAssetDetailOpen.
         setSelectedAsset(asset);
-        onAssetDetailOpen();
       }
       if (message.type === 'ASSET_CONTEXT_CLEARED') {
         setSelectedAsset(null);
@@ -251,7 +258,7 @@ const SidePanel = () => {
     return () => {
       chrome.runtime.onMessage.removeListener(messageListener);
     };
-  }, [onAssetDetailOpen, fetchTotalBalance]);
+  }, [fetchTotalBalance]);
 
   // Format currency for display
   const formatCurrency = (value: number) => {

--- a/pages/side-panel/src/SidePanel.tsx
+++ b/pages/side-panel/src/SidePanel.tsx
@@ -53,6 +53,11 @@ const SidePanel = () => {
   const [selectedAsset, setSelectedAsset] = useState<any>(null);
   const [balancesInitialLoading, setBalancesInitialLoading] = useState(true);
   const [pendingEvent, setPendingEvent] = useState<any | null>(null);
+  // "Add blockchain" picker takeover — lifted out of <Balances> so the home
+  // button and dashboard-hiding logic can see it. Keeping it inside Balances
+  // meant SidePanel kept rendering the donut/balance/Send-Receive block on
+  // top of the picker, and the home button couldn't reset it.
+  const [showAddBlockchain, setShowAddBlockchain] = useState(false);
 
   // Disclosures for drawers/modals
   const { isOpen: isSettingsOpen, onOpen: onSettingsOpen, onClose: onSettingsClose } = useDisclosure();
@@ -91,6 +96,17 @@ const SidePanel = () => {
     onAssetDetailClose();
     setSelectedAsset(null);
     chrome.runtime.sendMessage({ type: 'CLEAR_ASSET_CONTEXT' });
+  };
+
+  // Shield-badge "home" action — collapse any open drawers and clear context
+  // so the user lands back on the Balances view.
+  const handleGoHome = () => {
+    if (isAssetDetailOpen) handleAssetDetailClose();
+    if (isSendOpen) onSendClose();
+    if (isReceiveOpen) onReceiveClose();
+    if (transactionContext) setTransactionContext(null);
+    if (showAddBlockchain) setShowAddBlockchain(false);
+    setSelectedAsset(null);
   };
 
   // Prefer native chain rows over ERC-20 / SPL tokens when picking a
@@ -277,7 +293,13 @@ const SidePanel = () => {
       case 4:
         return <Connect setIsConnecting={setIsConnecting} />;
       case 5:
-        return <Balances onSelectAsset={handleAssetSelect} />;
+        return (
+          <Balances
+            onSelectAsset={handleAssetSelect}
+            showAddBlockchain={showAddBlockchain}
+            setShowAddBlockchain={setShowAddBlockchain}
+          />
+        );
       default:
         return (
           <Flex direction="column" justifyContent="center" alignItems="center" height="100%" minH="300px">
@@ -315,7 +337,7 @@ const SidePanel = () => {
   // while an approval is live — matches the old popup's singular-focus UX.
   if (pendingEvent) {
     return (
-      <Flex direction="column" width="100%" height="100vh" bg="gray.900" overflowY="auto" p={4}>
+      <Flex direction="column" width="100%" height="100vh" bg="kk.bg" overflowY="auto" p={4}>
         <Transaction event={pendingEvent} reloadEvents={fetchPendingEvent} onDismiss={fetchPendingEvent} />
       </Flex>
     );
@@ -324,11 +346,23 @@ const SidePanel = () => {
   return (
     <Flex direction="column" width="100%" height="100vh">
       {/* Sticky header — floats above drawers */}
-      <Box position="sticky" top={0} zIndex={1500} bg="gray.900" px={4} pt={4} pb={1} flexShrink={0} overflow="visible">
+      <Box
+        position="sticky"
+        top={0}
+        zIndex={1500}
+        bg="kk.bg"
+        borderBottom="1px solid"
+        borderColor="kk.line"
+        px={4}
+        pt={4}
+        pb={2}
+        flexShrink={0}
+        overflow="visible">
         <NetworkAccountHeader
           keepkeyState={keepkeyState}
           isRefreshing={isRefreshing}
           onSettingsOpen={onSettingsOpen}
+          onHome={handleGoHome}
           onRefresh={refreshBalances}
           onSelectNetwork={handleAssetSelect}
         />
@@ -337,20 +371,22 @@ const SidePanel = () => {
       {/* Scrollable body below header */}
       <Flex direction="column" flex={1} overflowY="auto" px={4} pb={4}>
         {/* Total Balance & Quick Actions - Only when paired and on home screen, after initial load */}
-        {keepkeyState === 5 && !transactionContext && !balancesInitialLoading && (
+        {keepkeyState === 5 && !transactionContext && !balancesInitialLoading && !showAddBlockchain && (
           <Box mb={3} textAlign="center">
             {balances.length > 0 && totalUsdBalance > 0 && (
               <Box mb={2}>
                 <DonutChart balances={balances} totalUsd={totalUsdBalance} />
               </Box>
             )}
-            <Heading size="lg" color="white" mb={2}>
+            <Text className="kk-eyebrow" mb={1}>
+              Total balance
+            </Text>
+            <Heading size="lg" color="kk.text" mb={3} fontWeight={700} letterSpacing="-0.6px" className="mono">
               {formatCurrency(totalUsdBalance)}
             </Heading>
-            <HStack spacing={3} justify="center">
+            <HStack spacing={2} justify="center">
               <Button
                 leftIcon={<ArrowUpIcon />}
-                colorScheme="blue"
                 variant="solid"
                 size="sm"
                 onClick={handleGlobalSend}
@@ -359,8 +395,7 @@ const SidePanel = () => {
               </Button>
               <Button
                 leftIcon={<ArrowDownIcon />}
-                colorScheme="green"
-                variant="solid"
+                variant="ghost"
                 size="sm"
                 onClick={handleGlobalReceive}
                 isDisabled={balances.length === 0}>
@@ -374,34 +409,35 @@ const SidePanel = () => {
         <Box flex={1}>{renderContent()}</Box>
       </Flex>
 
-      {/* Asset Detail Drawer */}
+      {/* Asset Detail Drawer — no title bar: the sticky NetworkAccountHeader
+          above already shows which network/account is active, so a second
+          "Ethereum" header would duplicate context. A small back button floats
+          over the body to preserve the close affordance. */}
       <Drawer isOpen={isAssetDetailOpen} placement="bottom" onClose={handleAssetDetailClose} size="full">
         <DrawerOverlay bg="blackAlpha.800" />
-        <DrawerContent bg="gray.900" h={`calc(100vh - ${HEADER_HEIGHT})`} mt={HEADER_HEIGHT}>
-          <DrawerHeader borderBottomWidth="1px" borderColor="whiteAlpha.200" py={3}>
-            <Flex align="center" w="full">
-              <IconButton
-                aria-label="Go back"
-                icon={<ChevronLeftIcon boxSize={6} />}
-                variant="ghost"
-                size="sm"
-                onClick={handleAssetDetailClose}
-                mr={2}
-              />
-              <Text fontWeight="semibold" fontSize="lg">
-                {selectedAsset?.name || 'Asset'}
-              </Text>
-            </Flex>
-          </DrawerHeader>
-          <DrawerBody>
-            {selectedAsset && (
-              <AssetDetail
-                asset={selectedAsset}
-                balances={balances}
-                onSend={handleAssetSend}
-                onReceive={handleAssetReceive}
-              />
-            )}
+        <DrawerContent bg="kk.bg" h={`calc(100vh - ${HEADER_HEIGHT})`} mt={HEADER_HEIGHT}>
+          <DrawerBody p={0} position="relative">
+            <IconButton
+              aria-label="Close asset"
+              icon={<ChevronLeftIcon boxSize={5} />}
+              variant="ghost"
+              size="sm"
+              onClick={handleAssetDetailClose}
+              position="absolute"
+              top={2}
+              left={2}
+              zIndex={2}
+            />
+            <Box pt={10} px={4} pb={4}>
+              {selectedAsset && (
+                <AssetDetail
+                  asset={selectedAsset}
+                  balances={balances}
+                  onSend={handleAssetSend}
+                  onReceive={handleAssetReceive}
+                />
+              )}
+            </Box>
           </DrawerBody>
         </DrawerContent>
       </Drawer>
@@ -425,7 +461,7 @@ const SidePanel = () => {
       {/* Send Drawer */}
       <Drawer isOpen={isSendOpen} placement="bottom" onClose={onSendClose} size="full">
         <DrawerOverlay bg="blackAlpha.800" />
-        <DrawerContent bg="gray.900" h={`calc(100vh - ${HEADER_HEIGHT})`} mt={HEADER_HEIGHT}>
+        <DrawerContent bg="kk.bg" h={`calc(100vh - ${HEADER_HEIGHT})`} mt={HEADER_HEIGHT}>
           <DrawerHeader borderBottomWidth="1px" borderColor="whiteAlpha.200" py={3}>
             <Flex align="center" w="full">
               <IconButton
@@ -450,7 +486,7 @@ const SidePanel = () => {
       {/* Receive Drawer */}
       <Drawer isOpen={isReceiveOpen} placement="bottom" onClose={onReceiveClose} size="full">
         <DrawerOverlay bg="blackAlpha.800" />
-        <DrawerContent bg="gray.900" h={`calc(100vh - ${HEADER_HEIGHT})`} mt={HEADER_HEIGHT}>
+        <DrawerContent bg="kk.bg" h={`calc(100vh - ${HEADER_HEIGHT})`} mt={HEADER_HEIGHT}>
           <DrawerHeader borderBottomWidth="1px" borderColor="whiteAlpha.200" py={3}>
             <Flex align="center" w="full">
               <IconButton

--- a/pages/side-panel/src/SidePanel.tsx
+++ b/pages/side-panel/src/SidePanel.tsx
@@ -428,7 +428,7 @@ const SidePanel = () => {
               left={2}
               zIndex={2}
             />
-            <Box pt={10} px={4} pb={4}>
+            <Box pt={10} px={4} pb={4} h="full">
               {selectedAsset && (
                 <AssetDetail
                   asset={selectedAsset}
@@ -487,23 +487,21 @@ const SidePanel = () => {
       <Drawer isOpen={isReceiveOpen} placement="bottom" onClose={onReceiveClose} size="full">
         <DrawerOverlay bg="blackAlpha.800" />
         <DrawerContent bg="kk.bg" h={`calc(100vh - ${HEADER_HEIGHT})`} mt={HEADER_HEIGHT}>
-          <DrawerHeader borderBottomWidth="1px" borderColor="whiteAlpha.200" py={3}>
-            <Flex align="center" w="full">
-              <IconButton
-                aria-label="Go back"
-                icon={<ChevronLeftIcon boxSize={6} />}
-                variant="ghost"
-                size="sm"
-                onClick={onReceiveClose}
-                mr={2}
-              />
-              <Text fontWeight="semibold" fontSize="lg">
-                Receive
-              </Text>
-            </Flex>
-          </DrawerHeader>
-          <DrawerBody p={0}>
-            <Receive onClose={onReceiveClose} balances={balances} />
+          <DrawerBody p={0} position="relative">
+            <IconButton
+              aria-label="Close receive"
+              icon={<ChevronLeftIcon boxSize={5} />}
+              variant="ghost"
+              size="sm"
+              onClick={onReceiveClose}
+              position="absolute"
+              top={2}
+              left={2}
+              zIndex={2}
+            />
+            <Box pt={10} h="full">
+              <Receive onClose={onReceiveClose} balances={balances} />
+            </Box>
           </DrawerBody>
         </DrawerContent>
       </Drawer>

--- a/pages/side-panel/src/components/AssetDetail.tsx
+++ b/pages/side-panel/src/components/AssetDetail.tsx
@@ -170,6 +170,7 @@ const AssetDetail = ({ asset, balances, onSend, onReceive }: AssetDetailProps) =
           <Text fontSize="sm" fontWeight="medium" color="whiteAlpha.600">
             {asset.name || asset.symbol}
           </Text>
+          {asset.networkId === 'tron:27Lqcw' && <TronLinkBadge />}
         </HStack>
         <Text fontSize="xl" fontWeight="bold" color="white" lineHeight="1.2">
           {formatUsd(totalUsdValue)}
@@ -389,5 +390,37 @@ const AssetDetail = ({ asset, balances, onSend, onReceive }: AssetDetailProps) =
     </Flex>
   );
 };
+
+// Passive indicator shown next to the asset name on the Tron asset page —
+// tells the user Tron dApps use the TronLink protocol (which KeepKey
+// implements). Not a link; TronLink is an unaffiliated wallet.
+const TronLinkBadge = () => (
+  <Flex
+    alignItems="center"
+    gap={1}
+    px={1.5}
+    py={0.5}
+    borderRadius="full"
+    bg="rgba(47,94,252,0.14)"
+    border="1px solid"
+    borderColor="rgba(47,94,252,0.36)">
+    <Flex w="10px" h="10px" borderRadius="full" bg="#2f5efc" alignItems="center" justifyContent="center" flexShrink={0}>
+      <TronLinkGlyph size={6} />
+    </Flex>
+    <Text fontSize="9px" color="#8fa9ff" letterSpacing="0.06em" fontWeight={600} textTransform="uppercase">
+      TronLink
+    </Text>
+  </Flex>
+);
+
+// Minimal TronLink mark — triangle/paper-plane silhouette in white.
+const TronLinkGlyph = ({ size = 16 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <path
+      d="M4.5 5.5L19.5 11.2c.6.24.6 1.1 0 1.34l-6.6 2.64-2.64 6.6c-.24.6-1.1.6-1.34 0L3.18 6.84c-.24-.6.36-1.2.96-.96l.36.12z"
+      fill="white"
+    />
+  </svg>
+);
 
 export default AssetDetail;

--- a/pages/side-panel/src/components/AssetDetail.tsx
+++ b/pages/side-panel/src/components/AssetDetail.tsx
@@ -42,6 +42,7 @@ const AssetDetail = ({ asset, balances, onSend, onReceive }: AssetDetailProps) =
   const toast = useToast();
 
   const isEvm = asset.networkId?.startsWith('eip155:');
+  const isUtxo = asset.networkId?.startsWith('bip122:');
 
   // Fallback: cached Pioneer balance for non-EVM or while loading
   const chainBalances = balances.filter(b => b.networkId === asset.networkId);
@@ -75,6 +76,32 @@ const AssetDetail = ({ asset, balances, onSend, onReceive }: AssetDetailProps) =
     setLiveUsdValue(null);
     setLivePriceUsd(null);
 
+    // UTXO chains: pubkey-list rows have empty .address and Pioneer's
+    // /portfolio response stuffs the xpub into b.address (line ~439 in
+    // background/index.ts), so falling back to asset.pubkeys[0].address
+    // or asset.address would surface either nothing or an unusable
+    // xpub string in the address bar / explorer link. Derive the real
+    // receive address via GET_UTXO_ADDRESS using the asset's note +
+    // script_type (which the header / SET_ASSET_CONTEXT enrichment
+    // both populate).
+    if (isUtxo && asset.networkId) {
+      setLoadingAddress(true);
+      chrome.runtime.sendMessage(
+        {
+          type: 'GET_UTXO_ADDRESS',
+          networkId: asset.networkId,
+          scriptType: asset.script_type,
+          note: asset.note,
+        },
+        response => {
+          if (response?.address) setAddress(response.address);
+          else setAddress('');
+          setLoadingAddress(false);
+        },
+      );
+      return;
+    }
+
     const accountAddress = asset.pubkeys?.[0]?.address || asset.address || '';
     if (accountAddress) {
       setAddress(accountAddress);
@@ -102,7 +129,7 @@ const AssetDetail = ({ asset, balances, onSend, onReceive }: AssetDetailProps) =
         },
       );
     }
-  }, [asset.networkId, asset.address, asset.pubkeys?.[0]?.address, isEvm]);
+  }, [asset.networkId, asset.address, asset.pubkeys?.[0]?.address, asset.note, asset.script_type, isEvm, isUtxo]);
 
   // Load activity events filtered by networkId
   useEffect(() => {

--- a/pages/side-panel/src/components/AssetDetail.tsx
+++ b/pages/side-panel/src/components/AssetDetail.tsx
@@ -163,6 +163,12 @@ const AssetDetail = ({ asset, balances, onSend, onReceive }: AssetDetailProps) =
 
   return (
     <Flex direction="column" h="100%" minH={0}>
+      {/* Top spacer — pushes hero/address/buttons up off the top edge.
+          Smaller than the tabs flex grow below (1 : 2) so the hero sits at
+          roughly the upper third rather than dead-center; visually the
+          balance + Send/Receive block reads as the focal point. */}
+      <Box flex={1} minH={0} flexShrink={1} />
+
       {/* Balance Hero */}
       <VStack spacing={1} align="center" pt={3} pb={2} px={2} flexShrink={0}>
         <HStack spacing={2} align="center">
@@ -259,20 +265,23 @@ const AssetDetail = ({ asset, balances, onSend, onReceive }: AssetDetailProps) =
         </Button>
       </HStack>
 
-      {/* Tab Bar — Tokens / Activity */}
-      <Box flex={1} minH={0} px={2}>
+      {/* Tab Bar — Tokens / Activity. flex={2} vs the top spacer's flex={1}
+          biases the hero block higher (≈ upper third) instead of dead-center. */}
+      <Box flex={2} minH={0} px={2}>
         <Tabs variant="soft-rounded" colorScheme="blue" size="sm" display="flex" flexDirection="column" h="100%">
           <TabList mb={1} gap={1} flexShrink={0}>
-            <Tab
-              color="whiteAlpha.500"
-              _selected={{ color: 'white', bg: 'whiteAlpha.150' }}
-              fontSize="xs"
-              fontWeight="medium"
-              py={1}
-              px={3}
-              borderRadius="md">
-              Tokens
-            </Tab>
+            {!isUtxoNetwork && (
+              <Tab
+                color="whiteAlpha.500"
+                _selected={{ color: 'white', bg: 'whiteAlpha.150' }}
+                fontSize="xs"
+                fontWeight="medium"
+                py={1}
+                px={3}
+                borderRadius="md">
+                Tokens
+              </Tab>
+            )}
             <Tab
               color="whiteAlpha.500"
               _selected={{ color: 'white', bg: 'whiteAlpha.150' }}
@@ -290,18 +299,14 @@ const AssetDetail = ({ asset, balances, onSend, onReceive }: AssetDetailProps) =
             </Tab>
           </TabList>
           <TabPanels flex={1} minH={0} overflowY="auto">
-            {/* Tokens Tab */}
-            <TabPanel p={0}>
-              {isUtxoNetwork ? (
-                <VStack align="center" py={6}>
-                  <Text fontSize="sm" color="whiteAlpha.500">
-                    No tokens for UTXO chains
-                  </Text>
-                </VStack>
-              ) : (
+            {/* Tokens Tab — hidden on chains that don't support tokens
+                (currently UTXO). Both the Tab and its TabPanel are dropped
+                together so Chakra's positional indexing stays in sync. */}
+            {!isUtxoNetwork && (
+              <TabPanel p={0}>
                 <Tokens asset={{ ...asset, address }} networkId={asset.networkId} />
-              )}
-            </TabPanel>
+              </TabPanel>
+            )}
 
             {/* Activity Tab */}
             <TabPanel p={0}>

--- a/pages/side-panel/src/components/Balances.tsx
+++ b/pages/side-panel/src/components/Balances.tsx
@@ -1,18 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import {
-  Flex,
-  Spinner,
-  Avatar,
-  Box,
-  Text,
-  Badge,
-  Card,
-  Stack,
-  HStack,
-  Skeleton,
-  SkeletonCircle,
-} from '@chakra-ui/react';
-import { ChevronRightIcon } from '@chakra-ui/icons';
+import { Flex, Avatar, Box, Text, Card, Stack, HStack, Skeleton, SkeletonCircle } from '@chakra-ui/react';
 import AssetSelect from './AssetSelect';
 import { COIN_MAP_LONG, NetworkIdToChain } from '@extension/shared';
 
@@ -34,13 +21,15 @@ const getChainDisplayName = (networkId: string): string => {
 
 interface BalancesProps {
   onSelectAsset: (asset: any) => void;
+  /** Controlled by SidePanel so the home button + dashboard-gating can see it. */
+  showAddBlockchain: boolean;
+  setShowAddBlockchain: (show: boolean) => void;
 }
 
-const Balances = ({ onSelectAsset }: BalancesProps) => {
+const Balances = ({ onSelectAsset, showAddBlockchain, setShowAddBlockchain }: BalancesProps) => {
   const [balances, setBalances] = useState<any[]>([]);
   const [assets, setAssets] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
-  const [showAssetSelect, setShowAssetSelect] = useState(false);
 
   const formatBalance = (balance: string) => {
     const numericBalance = parseFloat(balance);
@@ -90,20 +79,20 @@ const Balances = ({ onSelectAsset }: BalancesProps) => {
     return valueB - valueA;
   });
 
-  if (showAssetSelect) {
-    return <AssetSelect setShowBack={() => {}} setShowAssetSelect={setShowAssetSelect} />;
+  if (showAddBlockchain) {
+    return <AssetSelect setShowAssetSelect={setShowAddBlockchain} />;
   }
 
   if (loading) {
     const SkeletonRow = ({ delay = 0 }: { delay?: number }) => (
       <Card
-        borderRadius="lg"
+        borderRadius="12px"
         p={3}
-        mb={2}
+        mb={1.5}
         width="100%"
-        bg="rgba(255, 255, 255, 0.03)"
+        bg="kk.surface"
         border="1px solid"
-        borderColor="whiteAlpha.100"
+        borderColor="kk.line"
         position="relative"
         overflow="hidden"
         sx={{
@@ -123,13 +112,38 @@ const Balances = ({ onSelectAsset }: BalancesProps) => {
           <SkeletonCircle size="10" startColor="whiteAlpha.100" endColor="whiteAlpha.300" />
           <Box ml={3} flex="1" minWidth="0">
             <HStack spacing={2}>
-              <Skeleton height="14px" width="60px" borderRadius="sm" startColor="whiteAlpha.100" endColor="whiteAlpha.300" />
-              <Skeleton height="14px" width="44px" borderRadius="full" startColor="whiteAlpha.100" endColor="whiteAlpha.200" />
+              <Skeleton
+                height="14px"
+                width="60px"
+                borderRadius="sm"
+                startColor="whiteAlpha.100"
+                endColor="whiteAlpha.300"
+              />
+              <Skeleton
+                height="14px"
+                width="44px"
+                borderRadius="full"
+                startColor="whiteAlpha.100"
+                endColor="whiteAlpha.200"
+              />
             </HStack>
-            <Skeleton mt={2} height="12px" width="96px" borderRadius="sm" startColor="whiteAlpha.100" endColor="whiteAlpha.300" />
+            <Skeleton
+              mt={2}
+              height="12px"
+              width="96px"
+              borderRadius="sm"
+              startColor="whiteAlpha.100"
+              endColor="whiteAlpha.300"
+            />
           </Box>
           <Flex direction="column" align="flex-end" minW="80px">
-            <Skeleton height="14px" width="56px" borderRadius="sm" startColor="whiteAlpha.100" endColor="whiteAlpha.300" />
+            <Skeleton
+              height="14px"
+              width="56px"
+              borderRadius="sm"
+              startColor="whiteAlpha.100"
+              endColor="whiteAlpha.300"
+            />
           </Flex>
         </Flex>
       </Card>
@@ -194,14 +208,7 @@ const Balances = ({ onSelectAsset }: BalancesProps) => {
         </Box>
 
         {/* Hero spinner above the skeletons */}
-        <Flex
-          direction="column"
-          align="center"
-          gap={3}
-          pt={2}
-          pb={5}
-          position="relative"
-          zIndex={2}>
+        <Flex direction="column" align="center" gap={3} pt={2} pb={5} position="relative" zIndex={2}>
           <Box position="relative" width="88px" height="88px">
             {/* Soft pulsing glow */}
             <Box
@@ -291,7 +298,9 @@ const Balances = ({ onSelectAsset }: BalancesProps) => {
       <Stack width="100%">
         {sortedAssets.length === 0 ? (
           <Flex justifyContent="center" alignItems="center" width="100%" minH="40vh">
-            <Text color="whiteAlpha.600">No assets found</Text>
+            <Text color="kk.faint" fontSize="sm">
+              No assets found
+            </Text>
           </Flex>
         ) : (
           <>
@@ -314,47 +323,52 @@ const Balances = ({ onSelectAsset }: BalancesProps) => {
               return (
                 <Card
                   key={index}
-                  borderRadius="lg"
+                  borderRadius="12px"
                   p={3}
-                  mb={2}
+                  mb={1.5}
                   width="100%"
-                  bg="rgba(255, 255, 255, 0.03)"
+                  bg="kk.surface"
                   border="1px solid"
-                  borderColor="whiteAlpha.100"
-                  _hover={{ bg: 'rgba(255, 255, 255, 0.06)', cursor: 'pointer' }}
+                  borderColor="kk.line"
+                  _hover={{ bg: 'kk.surfaceHi', cursor: 'pointer' }}
                   onClick={() => onSelectAsset(asset)}
-                  transition="all 0.2s">
-                  <Flex align="center" width="100%">
-                    <Avatar src={asset.icon} size="md" />
-                    <Box ml={3} flex="1" minWidth="0">
+                  transition="background 0.15s">
+                  <Flex align="center" width="100%" gap={3}>
+                    <Avatar src={asset.icon} size="sm" />
+                    <Box flex="1" minWidth="0">
                       <Flex align="center" gap={2}>
-                        <Text fontWeight="semibold" fontSize="md" isTruncated color="white">
+                        <Text fontWeight={600} fontSize="sm" isTruncated color="kk.text">
                           {asset.name}
                         </Text>
-                        <Badge size="sm" colorScheme="gray" variant="subtle" fontSize="10px" px={2} borderRadius="full">
+                        <Text
+                          as="span"
+                          fontSize="10px"
+                          px="6px"
+                          py="1px"
+                          borderRadius="full"
+                          bg="whiteAlpha.100"
+                          color="kk.faint"
+                          letterSpacing="0.04em">
                           {chainName}
-                        </Badge>
+                        </Text>
                       </Flex>
-                      <HStack spacing={2} mt={0.5}>
-                        <Text fontSize="md" color="white" fontWeight="medium">
+                      <HStack spacing={1} mt="2px">
+                        <Text fontSize="xs" color="kk.dim" className="mono">
                           {integer}.{largePart}
                           {largePart === '0000' && (
-                            <Text as="span" fontSize="xs" color="whiteAlpha.600">
+                            <Text as="span" color="kk.faint">
                               {smallPart}
                             </Text>
                           )}
-                          <Text as="span" color="whiteAlpha.700" ml={1} fontSize="sm">
-                            {asset.symbol}
-                          </Text>
+                        </Text>
+                        <Text as="span" color="kk.faint" fontSize="xs">
+                          {asset.symbol}
                         </Text>
                       </HStack>
                     </Box>
-                    <Flex direction="column" align="flex-end" minW="80px">
-                      <Text fontWeight="semibold" color="white" fontSize="md">
-                        ${formatUsd(totalUsdValue.toString())}
-                      </Text>
-                    </Flex>
-                    <ChevronRightIcon color="whiteAlpha.400" ml={2} />
+                    <Text fontWeight={600} color="kk.text" fontSize="sm" whiteSpace="nowrap">
+                      ${formatUsd(totalUsdValue.toString())}
+                    </Text>
                   </Flex>
                 </Card>
               );
@@ -363,16 +377,17 @@ const Balances = ({ onSelectAsset }: BalancesProps) => {
             <Flex
               align="center"
               justify="center"
-              p={4}
-              mt={2}
-              borderRadius="lg"
+              gap={1.5}
+              p={3}
+              mt={1}
+              borderRadius="12px"
               border="1px dashed"
-              borderColor="whiteAlpha.200"
-              _hover={{ borderColor: 'whiteAlpha.400', cursor: 'pointer' }}
-              onClick={() => setShowAssetSelect(true)}
-              transition="all 0.2s">
-              <Text color="whiteAlpha.600" fontSize="sm">
-                + Add Blockchain
+              borderColor="kk.line"
+              _hover={{ borderColor: 'kk.lineHi', cursor: 'pointer' }}
+              onClick={() => setShowAddBlockchain(true)}
+              transition="border-color 0.15s">
+              <Text color="kk.faint" fontSize="xs">
+                + Add blockchain
               </Text>
             </Flex>
           </>

--- a/pages/side-panel/src/components/DonutChart.tsx
+++ b/pages/side-panel/src/components/DonutChart.tsx
@@ -43,19 +43,12 @@ const DonutChart: React.FC<DonutChartProps> = ({ balances, totalUsd }) => {
   if (slices.length === 0) return null;
 
   const size = 120;
-  const strokeWidth = 16;
+  const strokeWidth = 10;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
 
   let cumulativeOffset = 0;
-
-  const formatCurrency = (value: number) =>
-    new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(value);
+  const chainCount = slices.length;
 
   return (
     <motion.div
@@ -65,6 +58,15 @@ const DonutChart: React.FC<DonutChartProps> = ({ balances, totalUsd }) => {
       <Flex align="center" justify="center" gap={3}>
         <Box position="relative" w={`${size}px`} h={`${size}px`}>
           <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+            {/* Track */}
+            <circle
+              cx={size / 2}
+              cy={size / 2}
+              r={radius}
+              fill="none"
+              stroke="rgba(255,255,255,0.06)"
+              strokeWidth={strokeWidth}
+            />
             {slices.map((slice, i) => {
               const pct = slice.value / totalUsd;
               const dashLength = pct * circumference;
@@ -98,8 +100,11 @@ const DonutChart: React.FC<DonutChartProps> = ({ balances, totalUsd }) => {
             align="center"
             justify="center"
             direction="column">
-            <Text fontSize="xs" fontWeight="bold" color="white" lineHeight={1}>
-              {formatCurrency(totalUsd)}
+            <Text className="kk-eyebrow" lineHeight={1}>
+              Portfolio
+            </Text>
+            <Text className="mono" fontSize="10px" color="kk.accent" mt="2px" lineHeight={1}>
+              {chainCount} {chainCount === 1 ? 'chain' : 'chains'}
             </Text>
           </Flex>
         </Box>
@@ -107,10 +112,10 @@ const DonutChart: React.FC<DonutChartProps> = ({ balances, totalUsd }) => {
           {slices.map((slice, i) => (
             <Flex key={i} align="center" gap={1.5}>
               <Box w="8px" h="8px" borderRadius="full" bg={slice.color} flexShrink={0} />
-              <Text fontSize="2xs" color="whiteAlpha.700" lineHeight={1.2}>
+              <Text fontSize="2xs" color="kk.dim" lineHeight={1.2}>
                 {slice.symbol}
               </Text>
-              <Text fontSize="2xs" color="whiteAlpha.500" lineHeight={1.2}>
+              <Text fontSize="2xs" color="kk.faint" lineHeight={1.2} className="mono">
                 {((slice.value / totalUsd) * 100).toFixed(0)}%
               </Text>
             </Flex>

--- a/pages/side-panel/src/components/NetworkAccountHeader.tsx
+++ b/pages/side-panel/src/components/NetworkAccountHeader.tsx
@@ -146,6 +146,13 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
         // falls back to scoped[0], and Receive shows account 0's address
         // even when the user picked account 2.
         accountIndex: account.accountIndex,
+        // UTXO accounts share an accountIndex (BTC has Legacy / Segwit /
+        // Native Segwit all under account 0). The script_type is what
+        // distinguishes them, so the background's pubkey scoping needs
+        // it; without it Receive defaults to the first chainConfig path
+        // and ignores the user's header selection. Snake_case to match
+        // the field name on raw pubkey objects.
+        script_type: account.scriptType,
       };
       chrome.runtime.sendMessage({ type: 'SET_ASSET_CONTEXT', asset });
       setHasAssetContext(true);

--- a/pages/side-panel/src/components/NetworkAccountHeader.tsx
+++ b/pages/side-panel/src/components/NetworkAccountHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { Flex, Text, Box, IconButton, Avatar, Tooltip, Icon, useToast, useDisclosure } from '@chakra-ui/react';
-import { SettingsIcon, CheckCircleIcon, WarningIcon, RepeatIcon } from '@chakra-ui/icons';
+import { Flex, Text, Box, IconButton, Tooltip, useToast, useDisclosure } from '@chakra-ui/react';
+import { SettingsIcon, RepeatIcon } from '@chakra-ui/icons';
 import { NetworkIdToChain } from '@extension/shared';
 
 import type { NetworkItem, AccountItem, CustomEvmNetwork, NetworkAccountHeaderProps } from './header/headerTypes';
@@ -15,6 +15,7 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
   isRefreshing,
   onSettingsOpen,
   onRefresh,
+  onHome,
   onSelectNetwork,
 }) => {
   const [pubkeys, setPubkeys] = useState<any[]>([]);
@@ -238,15 +239,48 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
     [fetchPubkeys, toast],
   );
 
+  // The shield badge encodes BOTH home-button and device status: its gradient
+  // tints to green when paired, red when errored, gold (brand default) while
+  // transient. One glyph, two jobs — no duplicate status indicator elsewhere.
+  const shieldStatus = isPaired
+    ? {
+        tooltip: stateNames[5],
+        gradient: 'linear-gradient(135deg, #57ce51 0%, #1f7e24 100%)',
+        edge: 'rgba(87,206,81,0.36)',
+        pulse: false,
+      }
+    : keepkeyState === 4
+      ? {
+          tooltip: stateNames[4],
+          gradient: 'linear-gradient(135deg, #e56a4d 0%, #8a2a18 100%)',
+          edge: 'rgba(229,106,77,0.36)',
+          pulse: false,
+        }
+      : {
+          tooltip: 'connecting…',
+          gradient: 'linear-gradient(135deg, #d29929 0%, #6d4a13 100%)',
+          edge: 'rgba(210,153,41,0.36)',
+          pulse: true,
+        };
+
   return (
     <Box mb={2}>
       <Flex alignItems="center" justifyContent="space-between" gap={2}>
-        {/* Left: Settings */}
-        <IconButton icon={<SettingsIcon />} aria-label="Settings" variant="ghost" size="sm" onClick={onSettingsOpen} />
+        {/* Left: shield-badge = home button AND device-status indicator */}
+        <Tooltip label={shieldStatus.tooltip} placement="bottom" hasArrow>
+          <span>
+            <ShieldBadge
+              onClick={onHome}
+              gradient={shieldStatus.gradient}
+              edge={shieldStatus.edge}
+              pulse={shieldStatus.pulse}
+            />
+          </span>
+        </Tooltip>
 
-        {/* Center: Branding or Network + Account dropdowns */}
+        {/* Center: Network + Account dropdowns when ready, wordmark otherwise */}
         {isPaired && hasAssetContext && networks.length > 0 ? (
-          <Flex flex={1} alignItems="center" justifyContent="center" gap={1} minW={0}>
+          <Flex flex={1} alignItems="center" justifyContent="center" gap={2} minW={0}>
             <NetworkDropdown
               networks={networks}
               selectedNetworkId={selectedNetworkId}
@@ -266,24 +300,14 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
           </Flex>
         ) : (
           <Flex flex={1} alignItems="center" justifyContent="center">
-            <Avatar size="xs" src="/kk-logo.png" name="KeepKey" mr={2} />
-            <Text fontSize="sm" fontWeight="semibold" color="white">
+            <Text fontSize="sm" fontWeight={700} color="kk.text" letterSpacing="-0.1px">
               KeepKey
             </Text>
           </Flex>
         )}
 
-        {/* Right: Status + Refresh */}
+        {/* Right: refresh + settings (status lives in the left shield now) */}
         <Flex alignItems="center" gap={1}>
-          <Tooltip label={keepkeyState !== null ? stateNames[keepkeyState] : 'unknown'} placement="bottom" hasArrow>
-            <span>
-              {isPaired ? (
-                <Icon as={CheckCircleIcon} color="green.400" boxSize={4} />
-              ) : (
-                <Icon as={WarningIcon} color="yellow.400" boxSize={4} />
-              )}
-            </span>
-          </Tooltip>
           <IconButton
             icon={<RepeatIcon />}
             aria-label="Refresh"
@@ -291,6 +315,13 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
             size="sm"
             isLoading={isRefreshing}
             onClick={onRefresh}
+          />
+          <IconButton
+            icon={<SettingsIcon />}
+            aria-label="Settings"
+            variant="ghost"
+            size="sm"
+            onClick={onSettingsOpen}
           />
         </Flex>
       </Flex>
@@ -300,5 +331,52 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
     </Box>
   );
 };
+
+// Gradient shield tile — acts as home button AND device-status indicator.
+// Tint comes from the active state (gold / green / red); a soft pulse plays
+// while we're still figuring out the state so the user sees "thinking…".
+const ShieldBadge = ({
+  onClick,
+  gradient,
+  edge,
+  pulse,
+}: {
+  onClick?: () => void;
+  gradient: string;
+  edge: string;
+  pulse?: boolean;
+}) => (
+  <Flex
+    as={onClick ? 'button' : 'div'}
+    onClick={onClick}
+    aria-label={onClick ? 'Home' : undefined}
+    w="32px"
+    h="32px"
+    flexShrink={0}
+    borderRadius="8px"
+    alignItems="center"
+    justifyContent="center"
+    bgImage={gradient}
+    boxShadow={`0 0 0 1px ${edge}, inset 0 1px 0 rgba(255,255,255,0.25), 0 0 14px -4px ${edge}`}
+    cursor={onClick ? 'pointer' : 'default'}
+    transition="filter 0.15s, transform 0.15s, box-shadow 0.3s"
+    sx={pulse ? { animation: 'kk-badge-pulse 1.4s ease-in-out infinite' } : undefined}
+    _hover={onClick ? { filter: 'brightness(1.1)' } : {}}
+    _active={onClick ? { transform: 'scale(0.95)' } : {}}>
+    <style>{`@keyframes kk-badge-pulse { 0%,100% { opacity: 0.7 } 50% { opacity: 1 } }`}</style>
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="#0b0d10"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round">
+      <path d="M12 3l7 3v6c0 4.5-3 7.5-7 8-4-.5-7-3.5-7-8V6l7-3z" />
+      <path d="M9 12l2 2 4-4" />
+    </svg>
+  </Flex>
+);
 
 export default NetworkAccountHeader;

--- a/pages/side-panel/src/components/NetworkAccountHeader.tsx
+++ b/pages/side-panel/src/components/NetworkAccountHeader.tsx
@@ -147,12 +147,14 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
         // even when the user picked account 2.
         accountIndex: account.accountIndex,
         // UTXO accounts share an accountIndex (BTC has Legacy / Segwit /
-        // Native Segwit all under account 0). The script_type is what
-        // distinguishes them, so the background's pubkey scoping needs
-        // it; without it Receive defaults to the first chainConfig path
-        // and ignores the user's header selection. Snake_case to match
-        // the field name on raw pubkey objects.
+        // Native Segwit all under account 0), and multiple paths can
+        // share a script_type (BTC account 0 and account 1 are both
+        // p2wpkh). Note is unique per chainConfig path, so it's what the
+        // background uses to scope GET_PUBKEY_CONTEXT exactly. Send
+        // both: GET_PUBKEY_CONTEXT prefers note, falls back to
+        // script_type / accountIndex.
         script_type: account.scriptType,
+        note: account.note,
       };
       chrome.runtime.sendMessage({ type: 'SET_ASSET_CONTEXT', asset });
       setHasAssetContext(true);

--- a/pages/side-panel/src/components/NetworkAccountHeader.tsx
+++ b/pages/side-panel/src/components/NetworkAccountHeader.tsx
@@ -104,29 +104,6 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
     return () => chrome.runtime.onMessage.removeListener(listener);
   }, [fetchPubkeys]);
 
-  // Auto-select an account when network changes. Priority:
-  //   1. Restore target (from persisted asset context on reload)
-  //   2. Current selection if still valid
-  //   3. isDefault → first account
-  useEffect(() => {
-    if (accounts.length === 0) return;
-    if (selectedAccountKey && accounts.find(a => a.key === selectedAccountKey)) return;
-
-    if (desiredAccountIndex !== null) {
-      const target = accounts.find(a => a.accountIndex === desiredAccountIndex);
-      if (target) {
-        setSelectedAccountKey(target.key);
-        setDesiredAccountIndex(null); // one-shot — don't keep overriding manual picks
-        return;
-      }
-      // Restore target doesn't exist (e.g. account was removed) — fall through.
-      setDesiredAccountIndex(null);
-    }
-
-    const defaultAcc = accounts.find(a => a.isDefault) || accounts[0];
-    setSelectedAccountKey(defaultAcc.key);
-  }, [accounts, selectedAccountKey, desiredAccountIndex]);
-
   // Helpers to fire SET_ASSET_CONTEXT and notify parent
   const setAssetContext = useCallback(
     (networkId: string, account: AccountItem) => {
@@ -188,6 +165,35 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
     },
     [selectedNetworkId, setAssetContext],
   );
+
+  // Auto-select an account when network changes. Priority:
+  //   1. Restore target (from persisted asset context on reload)
+  //   2. Current selection if still valid
+  //   3. isDefault → first account
+  // Also pushes SET_ASSET_CONTEXT to the background so the stored asset
+  // matches what the dropdown is showing — without this, the local UI
+  // could read "Native SegWit" while a stale or incomplete stored
+  // context made downstream Receive/Send default to legacy BTC.
+  useEffect(() => {
+    if (accounts.length === 0) return;
+    if (selectedAccountKey && accounts.find(a => a.key === selectedAccountKey)) return;
+
+    if (desiredAccountIndex !== null) {
+      const target = accounts.find(a => a.accountIndex === desiredAccountIndex);
+      if (target) {
+        setSelectedAccountKey(target.key);
+        setDesiredAccountIndex(null); // one-shot — don't keep overriding manual picks
+        if (selectedNetworkId) setAssetContext(selectedNetworkId, target);
+        return;
+      }
+      // Restore target doesn't exist (e.g. account was removed) — fall through.
+      setDesiredAccountIndex(null);
+    }
+
+    const defaultAcc = accounts.find(a => a.isDefault) || accounts[0];
+    setSelectedAccountKey(defaultAcc.key);
+    if (selectedNetworkId) setAssetContext(selectedNetworkId, defaultAcc);
+  }, [accounts, selectedAccountKey, desiredAccountIndex, selectedNetworkId, setAssetContext]);
 
   // ETH account add/remove
   const handleAddEthAccount = useCallback(() => {

--- a/pages/side-panel/src/components/NetworkAccountHeader.tsx
+++ b/pages/side-panel/src/components/NetworkAccountHeader.tsx
@@ -26,8 +26,15 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
   const [isAddingAccount, setIsAddingAccount] = useState(false);
   const [hasAssetContext, setHasAssetContext] = useState(false);
   // Held across pubkey load so the auto-select effect can land on the
-  // restored account instead of snapping back to the default.
+  // restored account instead of snapping back to the default. Note is
+  // checked first because UTXO chains (BTC) have multiple accounts at
+  // accountIndex 0 distinguished only by script_type — accountIndex
+  // alone restores to the wrong row (legacy when user wanted Native
+  // Segwit). script_type is a fallback for callers that didn't emit a
+  // note.
   const [desiredAccountIndex, setDesiredAccountIndex] = useState<number | null>(null);
+  const [desiredNote, setDesiredNote] = useState<string | null>(null);
+  const [desiredScriptType, setDesiredScriptType] = useState<string | null>(null);
   const toast = useToast();
 
   const { isOpen: isNetworkModalOpen, onOpen: onNetworkModalOpen, onClose: onNetworkModalClose } = useDisclosure();
@@ -61,14 +68,17 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
             setPubkeys(response.balances);
 
             // Restore selection from stored asset context. Carries
-            // accountIndex too so multi-account EVM picks survive a
-            // reload — without this the auto-select effect below
-            // snapped back to Account 0 every time.
+            // note + script_type + accountIndex so multi-account EVM
+            // picks AND multi-script BTC picks survive a reload —
+            // without all three the auto-select effect snaps back to
+            // the first chainConfig path on the network.
             chrome.runtime.sendMessage({ type: 'GET_ASSET_CONTEXT' }, ctxResponse => {
               const stored = ctxResponse?.assets;
               if (stored?.networkId) {
                 setSelectedNetworkId(stored.networkId);
                 setHasAssetContext(true);
+                if (stored.note) setDesiredNote(stored.note);
+                if (stored.script_type) setDesiredScriptType(stored.script_type);
                 if (stored.accountIndex !== undefined && stored.accountIndex !== null) {
                   setDesiredAccountIndex(stored.accountIndex);
                 }
@@ -91,20 +101,37 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
         fetchPubkeys();
       }
       if (message.type === 'ASSET_CONTEXT_UPDATED' && message.assetContext?.networkId) {
-        setSelectedNetworkId(message.assetContext.networkId);
+        const ctx = message.assetContext;
+        setSelectedNetworkId(ctx.networkId);
         setHasAssetContext(true);
+        // Feed desired* so the auto-select effect can re-target if the
+        // stored context now points to a different account on the same
+        // network. The effect compares against the current
+        // selectedAccountKey and is a no-op when the selection already
+        // matches, so this doesn't loop on the broadcast that fires
+        // back from our own SET_ASSET_CONTEXT.
+        setDesiredNote(ctx.note ?? null);
+        setDesiredScriptType(ctx.script_type ?? null);
+        setDesiredAccountIndex(ctx.accountIndex !== undefined && ctx.accountIndex !== null ? ctx.accountIndex : null);
       }
       if (message.type === 'ASSET_CONTEXT_CLEARED') {
         setSelectedNetworkId(null);
         setSelectedAccountKey(null);
         setHasAssetContext(false);
+        setDesiredNote(null);
+        setDesiredScriptType(null);
+        setDesiredAccountIndex(null);
       }
     };
     chrome.runtime.onMessage.addListener(listener);
     return () => chrome.runtime.onMessage.removeListener(listener);
   }, [fetchPubkeys]);
 
-  // Helpers to fire SET_ASSET_CONTEXT and notify parent
+  // Pure data setter — sends SET_ASSET_CONTEXT and updates local
+  // hasAssetContext. Returns the asset object so click handlers can
+  // pass it to onSelectNetwork. Side-effects (drawer-open) live in the
+  // click handlers, NOT here, so the auto-default effect can call this
+  // without triggering an unprompted AssetDetail drawer on cold start.
   const setAssetContext = useCallback(
     (networkId: string, account: AccountItem) => {
       const chainSymbol = NetworkIdToChain[networkId];
@@ -128,72 +155,100 @@ const NetworkAccountHeader: React.FC<NetworkAccountHeaderProps> = ({
         // share a script_type (BTC account 0 and account 1 are both
         // p2wpkh). Note is unique per chainConfig path, so it's what the
         // background uses to scope GET_PUBKEY_CONTEXT exactly. Send
-        // both: GET_PUBKEY_CONTEXT prefers note, falls back to
+        // all three: GET_PUBKEY_CONTEXT prefers note, falls back to
         // script_type / accountIndex.
         script_type: account.scriptType,
         note: account.note,
       };
       chrome.runtime.sendMessage({ type: 'SET_ASSET_CONTEXT', asset });
       setHasAssetContext(true);
-      if (onSelectNetwork) onSelectNetwork(asset);
+      return asset;
     },
-    [networks, onSelectNetwork],
+    [networks],
   );
 
-  // Network selected
+  // Network selected — user-initiated, opens AssetDetail.
   const handleNetworkSelect = useCallback(
     (net: NetworkItem) => {
       setSelectedNetworkId(net.networkId);
-      // Build accounts for this network and pick the default
       const accts = buildAccountList(pubkeys, net.networkId, ethAccounts);
       const defaultAcc = accts.find(a => a.isDefault) || accts[0];
       if (defaultAcc) {
         setSelectedAccountKey(defaultAcc.key);
-        setAssetContext(net.networkId, defaultAcc);
+        const asset = setAssetContext(net.networkId, defaultAcc);
+        if (onSelectNetwork) onSelectNetwork(asset);
       }
     },
-    [pubkeys, ethAccounts, setAssetContext],
+    [pubkeys, ethAccounts, setAssetContext, onSelectNetwork],
   );
 
-  // Account selected
+  // Account selected — user-initiated, opens AssetDetail.
   const handleAccountSelect = useCallback(
     (account: AccountItem) => {
       setSelectedAccountKey(account.key);
       if (selectedNetworkId) {
-        setAssetContext(selectedNetworkId, account);
+        const asset = setAssetContext(selectedNetworkId, account);
+        if (onSelectNetwork) onSelectNetwork(asset);
       }
     },
-    [selectedNetworkId, setAssetContext],
+    [selectedNetworkId, setAssetContext, onSelectNetwork],
   );
 
-  // Auto-select an account when network changes. Priority:
-  //   1. Restore target (from persisted asset context on reload)
-  //   2. Current selection if still valid
-  //   3. isDefault → first account
-  // Also pushes SET_ASSET_CONTEXT to the background so the stored asset
-  // matches what the dropdown is showing — without this, the local UI
-  // could read "Native SegWit" while a stale or incomplete stored
-  // context made downstream Receive/Send default to legacy BTC.
+  // Auto-select an account when accounts/desired identifiers change.
+  // Priority:
+  //   1. Restore target by note (unique per chainConfig path)
+  //   2. Restore target by script_type (UTXO fallback if note missing)
+  //   3. Restore target by accountIndex (multi-account EVM)
+  //   4. Current selection if still valid (no desired* set)
+  //   5. isDefault → first account
+  //
+  // Also pushes SET_ASSET_CONTEXT so the stored asset matches the
+  // dropdown — but only when the chosen key actually changes, otherwise
+  // the ASSET_CONTEXT_UPDATED broadcast that comes back would feed
+  // desired* and re-fire the effect indefinitely. The `silent` style
+  // for setAssetContext (it no longer calls onSelectNetwork) keeps
+  // this auto-default from opening AssetDetail unprompted.
   useEffect(() => {
     if (accounts.length === 0) return;
-    if (selectedAccountKey && accounts.find(a => a.key === selectedAccountKey)) return;
 
-    if (desiredAccountIndex !== null) {
-      const target = accounts.find(a => a.accountIndex === desiredAccountIndex);
-      if (target) {
+    const target =
+      (desiredNote && accounts.find(a => a.note === desiredNote)) ||
+      (desiredScriptType && accounts.find(a => a.scriptType === desiredScriptType)) ||
+      (desiredAccountIndex !== null && accounts.find(a => a.accountIndex === desiredAccountIndex)) ||
+      null;
+
+    if (target) {
+      // Always clear desired* (one-shot), only push to background when
+      // the account actually changes.
+      const changed = target.key !== selectedAccountKey;
+      if (changed) {
         setSelectedAccountKey(target.key);
-        setDesiredAccountIndex(null); // one-shot — don't keep overriding manual picks
         if (selectedNetworkId) setAssetContext(selectedNetworkId, target);
-        return;
       }
-      // Restore target doesn't exist (e.g. account was removed) — fall through.
-      setDesiredAccountIndex(null);
+      if (desiredNote !== null) setDesiredNote(null);
+      if (desiredScriptType !== null) setDesiredScriptType(null);
+      if (desiredAccountIndex !== null) setDesiredAccountIndex(null);
+      return;
     }
 
+    // No desired* targets — keep the current selection if it's still in
+    // the rebuilt accounts list, otherwise fall back to the default.
+    if (selectedAccountKey && accounts.find(a => a.key === selectedAccountKey)) return;
+
     const defaultAcc = accounts.find(a => a.isDefault) || accounts[0];
-    setSelectedAccountKey(defaultAcc.key);
-    if (selectedNetworkId) setAssetContext(selectedNetworkId, defaultAcc);
-  }, [accounts, selectedAccountKey, desiredAccountIndex, selectedNetworkId, setAssetContext]);
+    if (defaultAcc) {
+      setSelectedAccountKey(defaultAcc.key);
+      if (selectedNetworkId) setAssetContext(selectedNetworkId, defaultAcc);
+    }
+  }, [
+    accounts,
+    selectedAccountKey,
+    desiredNote,
+    desiredScriptType,
+    desiredAccountIndex,
+    selectedNetworkId,
+    setAssetContext,
+  ]);
 
   // ETH account add/remove
   const handleAddEthAccount = useCallback(() => {

--- a/pages/side-panel/src/components/Receive.tsx
+++ b/pages/side-panel/src/components/Receive.tsx
@@ -17,7 +17,7 @@ import {
   MenuItem,
 } from '@chakra-ui/react';
 import { CopyIcon, CheckIcon, ChevronDownIcon } from '@chakra-ui/icons';
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import QRCode from 'qrcode';
 
 interface ReceiveProps {
@@ -34,8 +34,21 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
   const [loading, setLoading] = useState(true);
   const [hasCopied, setHasCopied] = useState(false);
   const [qrCodeDataUrl, setQrCodeDataUrl] = useState<string | null>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  // UTXO pubkeys carry an xpub in `.pubkey` and an empty `.address`. We
+  // derive a real receive address per account and key them by `note`
+  // (which is unique per path config) so the dropdown can render real
+  // addresses and the switch handler can look up by pubkey identity
+  // instead of address string.
+  const [addressByNote, setAddressByNote] = useState<Record<string, string>>({});
   const toast = useToast();
+
+  const isUtxoNetwork = (networkId?: string) => !!networkId?.startsWith('bip122:');
+
+  const addressForPubkey = (pk: any): string => {
+    if (!pk) return '';
+    if (pk.note && addressByNote[pk.note]) return addressByNote[pk.note];
+    return pk.address || pk.master || '';
+  };
 
   // Fetch asset context, pubkeys, and current pubkey context from the backend (extension)
   useEffect(() => {
@@ -49,23 +62,55 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
           setLoading(false);
           return;
         }
-        if (response && response.assets) {
-          setAssetContext(response.assets);
-          setPubkeys(response.assets.pubkeys || []);
+        const ctxAsset = response?.assets;
+        if (ctxAsset) {
+          setAssetContext(ctxAsset);
+          setPubkeys(ctxAsset.pubkeys || []);
         }
         setLoading(false);
+
+        // UTXO chains have no plain .address on the pubkey (the batch
+        // endpoint returns { pubkey: xpub, address: '' }). Derive a real
+        // receive address per account so the dropdown can show actual
+        // addresses and the switch handler has something to look up.
+        if (isUtxoNetwork(ctxAsset?.networkId) && ctxAsset?.networkId) {
+          const allPks = (ctxAsset.pubkeys || []) as any[];
+          allPks.forEach((pk, idx) => {
+            if (!pk?.note) return;
+            chrome.runtime.sendMessage(
+              {
+                type: 'GET_UTXO_ADDRESS',
+                networkId: ctxAsset.networkId,
+                scriptType: pk.scriptType,
+                note: pk.note,
+              },
+              utxoResp => {
+                if (!utxoResp?.address) return;
+                setAddressByNote(prev => ({ ...prev, [pk.note]: utxoResp.address }));
+                if (idx === 0) setSelectedAddress(utxoResp.address);
+              },
+            );
+          });
+        }
       });
 
-      // Fetch current pubkey context to default to the selected account
+      // Non-UTXO: pick the scoped pubkey's address directly
       chrome.runtime.sendMessage({ type: 'GET_PUBKEY_CONTEXT' }, response => {
         if (chrome.runtime.lastError) {
           console.error('Error fetching pubkey context:', chrome.runtime.lastError.message);
           return;
         }
-        if (response && response.pubkeyContext) {
-          setPubkeyContext(response.pubkeyContext);
-          const address = response.pubkeyContext.address || response.pubkeyContext.master;
-          setSelectedAddress(address);
+        const pc = response?.pubkeyContext;
+        if (pc) {
+          setPubkeyContext(pc);
+          // .address is the populated field for account-based chains.
+          // .master was the legacy xpub field; .pubkey is the new field
+          // name (UTXO). We intentionally skip UTXO values here — the
+          // utxoGetAddress branch above handles those.
+          const isUtxo = pc.type === 'xpub' || pc.type === 'zpub' || !pc.address;
+          if (!isUtxo && pc.address) {
+            setSelectedAddress(pc.address);
+          }
         }
       });
     };
@@ -96,34 +141,50 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
     return () => chrome.runtime.onMessage.removeListener(messageListener);
   }, []);
 
-  const handleAddressSelect = (address: string) => {
-    // Find the pubkey object that matches this address
-    const selectedPubkey = pubkeys.find(pk => (pk.address || pk.master) === address);
-    if (selectedPubkey) {
-      // Update global pubkey context
-      chrome.runtime.sendMessage({ type: 'SET_PUBKEY_CONTEXT', pubkey: selectedPubkey }, response => {
-        if (response?.success) {
-          setPubkeyContext(response.pubkeyContext);
-          setSelectedAddress(address);
-          toast({
-            title: 'Account switched',
-            description: `Now using ${getAddressType(selectedPubkey, pubkeys.indexOf(selectedPubkey))}`,
-            status: 'success',
-            duration: 2000,
-            isClosable: true,
-          });
-        } else if (response?.error) {
-          console.error('Error setting pubkey context:', response.error);
-          toast({
-            title: 'Error switching account',
-            description: response.error,
-            status: 'error',
-            duration: 3000,
-            isClosable: true,
-          });
+  const handleAccountSelect = (pubkey: any, index: number) => {
+    if (!pubkey) return;
+    chrome.runtime.sendMessage({ type: 'SET_PUBKEY_CONTEXT', pubkey }, response => {
+      if (response?.success) {
+        setPubkeyContext(response.pubkeyContext);
+        const resolved = addressForPubkey(pubkey);
+        if (resolved) {
+          setSelectedAddress(resolved);
+        } else if (isUtxoNetwork(assetContext?.networkId) && assetContext?.networkId && pubkey.note) {
+          // Address wasn't pre-derived (e.g. batch derive still in flight) —
+          // fetch it on demand. Cache so a later render picks it up too.
+          chrome.runtime.sendMessage(
+            {
+              type: 'GET_UTXO_ADDRESS',
+              networkId: assetContext.networkId,
+              scriptType: pubkey.scriptType,
+              note: pubkey.note,
+            },
+            utxoResp => {
+              if (utxoResp?.address) {
+                setAddressByNote(prev => ({ ...prev, [pubkey.note]: utxoResp.address }));
+                setSelectedAddress(utxoResp.address);
+              }
+            },
+          );
         }
-      });
-    }
+        toast({
+          title: 'Account switched',
+          description: `Now using ${getAddressType(pubkey, index)}`,
+          status: 'success',
+          duration: 2000,
+          isClosable: true,
+        });
+      } else if (response?.error) {
+        console.error('Error setting pubkey context:', response.error);
+        toast({
+          title: 'Error switching account',
+          description: response.error,
+          status: 'error',
+          duration: 3000,
+          isClosable: true,
+        });
+      }
+    });
   };
 
   // Copy to clipboard function
@@ -239,29 +300,39 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
     return `${address.slice(0, 8)}...${address.slice(-8)}`;
   };
 
-  // Get address type label - show Account 0, 1, 2 etc.
+  const SCRIPT_TYPE_LABELS: Record<string, string> = {
+    p2pkh: 'Legacy',
+    'p2sh-p2wpkh': 'Segwit',
+    p2wpkh: 'Native Segwit',
+    p2tr: 'Taproot',
+  };
+
+  // Build a label like "Account 0 · Native Segwit" so multiple pubkeys for
+  // the same account (BTC has up to 3 — legacy / segwit / native segwit)
+  // don't all read as bare "Account 0".
   const getAddressType = (pubkey: any, index: number) => {
     if (!pubkey) return `Account ${index}`;
-    // Try to extract account number from note if available
+
+    let accountNum: number | string | null = null;
     if (pubkey.note) {
       const match = pubkey.note.match(/account\s*(\d+)/i);
-      if (match) {
-        return `Account ${match[1]}`;
-      }
+      if (match) accountNum = match[1];
     }
-    // Try to get from addressNList (last element is usually the account index)
-    if (pubkey.addressNList && pubkey.addressNList.length > 0) {
-      const lastIndex = pubkey.addressNList[pubkey.addressNList.length - 1];
-      return `Account ${lastIndex}`;
+    if (accountNum === null && Array.isArray(pubkey.addressNList) && pubkey.addressNList.length >= 3) {
+      // 3rd segment is the account index, hardened (≥ 0x80000000) for UTXO.
+      const seg = pubkey.addressNList[2];
+      accountNum = typeof seg === 'number' ? (seg >= 0x80000000 ? seg - 0x80000000 : seg) : null;
     }
-    // Fallback to index in list
-    return `Account ${index}`;
+    if (accountNum === null) accountNum = index;
+
+    const stLabel = pubkey.scriptType ? SCRIPT_TYPE_LABELS[pubkey.scriptType.toLowerCase()] : null;
+    return stLabel ? `Account ${accountNum} · ${stLabel}` : `Account ${accountNum}`;
   };
 
   if (loading) {
     return (
       <Flex align="center" justify="center" minHeight="200px">
-        <Spinner size="lg" />
+        <Spinner size="lg" color="kk.accent" />
       </Flex>
     );
   }
@@ -269,7 +340,7 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
   if (!assetContext) {
     return (
       <Flex align="center" justify="center" minHeight="200px">
-        <Text>No asset context available</Text>
+        <Text color="kk.faint">No asset context available</Text>
       </Flex>
     );
   }
@@ -316,7 +387,7 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
   };
 
   return (
-    <VStack spacing={4} align="center" p={4} h="full">
+    <VStack spacing={4} align="center" justify="center" p={4} h="full">
       {/* Token Selector — dedup by CAIP so tokens that share a ticker but
           live on different chains (or different contracts within the same
           chain) don't collapse. Deduping by `symbol` alone let e.g. bridged
@@ -345,31 +416,44 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
                   as={Button}
                   rightIcon={<ChevronDownIcon />}
                   w="full"
-                  bg="whiteAlpha.100"
-                  _hover={{ bg: 'whiteAlpha.200' }}
-                  _active={{ bg: 'whiteAlpha.200' }}
-                  borderRadius="xl"
-                  py={6}>
+                  bg="kk.surface"
+                  color="kk.text"
+                  border="1px solid"
+                  borderColor="kk.line"
+                  _hover={{ bg: 'kk.surfaceHi' }}
+                  _active={{ bg: 'kk.surfaceHi' }}
+                  borderRadius="12px"
+                  py={5}
+                  fontWeight={500}>
                   <HStack spacing={3} justify="center">
                     <Avatar size="sm" src={assetContext?.icon} />
-                    <Text fontWeight="semibold">{assetContext?.name}</Text>
-                    <Badge colorScheme="gray" fontSize="xs">
+                    <Text fontWeight={600}>{assetContext?.name}</Text>
+                    <Badge
+                      bg="whiteAlpha.100"
+                      color="kk.faint"
+                      fontSize="10px"
+                      borderRadius="full"
+                      px={2}
+                      textTransform="uppercase"
+                      letterSpacing="0.04em">
                       {assetContext?.symbol}
                     </Badge>
                   </HStack>
                 </MenuButton>
-                <MenuList bg="gray.800" borderColor="whiteAlpha.200" maxH="300px" overflowY="auto">
+                <MenuList bg="kk.surfaceHi" borderColor="kk.lineHi" maxH="300px" overflowY="auto">
                   {uniqueTokens.map((token, index) => (
                     <MenuItem
                       key={index}
                       onClick={() => handleTokenSelect(token)}
-                      bg={assetContext?.symbol === token.symbol ? 'whiteAlpha.200' : 'transparent'}
+                      bg={assetContext?.symbol === token.symbol ? 'whiteAlpha.100' : 'transparent'}
                       _hover={{ bg: 'whiteAlpha.100' }}>
                       <HStack spacing={3}>
                         <Avatar size="sm" src={token.icon} />
                         <VStack align="start" spacing={0}>
-                          <Text fontWeight="medium">{token.name}</Text>
-                          <Text fontSize="xs" color="whiteAlpha.600">
+                          <Text fontWeight={500} color="kk.text">
+                            {token.name}
+                          </Text>
+                          <Text fontSize="xs" color="kk.faint">
                             {token.symbol}
                           </Text>
                         </VStack>
@@ -394,13 +478,7 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
       </Box>
 
       {/* Combined Address Display with Selector and Copy */}
-      <Box
-        w="full"
-        bg="rgba(255, 255, 255, 0.05)"
-        border="1px solid"
-        borderColor="whiteAlpha.200"
-        borderRadius="xl"
-        p={4}>
+      <Box w="full" bg="kk.surface" border="1px solid" borderColor="kk.line" borderRadius="12px" p={4}>
         <Flex align="center" justify="space-between">
           {/* Address with optional dropdown */}
           <Menu>
@@ -411,35 +489,35 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
               _hover={pubkeys.length > 1 ? { opacity: 0.8 } : {}}>
               <Flex align="center">
                 <Box flex={1} overflow="hidden">
-                  <Text fontSize="xs" color="whiteAlpha.500" mb={1}>
+                  <Text className="kk-eyebrow" mb={1}>
                     {getAddressType(
-                      pubkeys.find(p => (p.address || p.master) === selectedAddress) || pubkeys[0],
-                      pubkeys.findIndex(p => (p.address || p.master) === selectedAddress),
+                      pubkeys.find(p => addressForPubkey(p) === selectedAddress) || pubkeys[0],
+                      pubkeys.findIndex(p => addressForPubkey(p) === selectedAddress),
                     )}
                   </Text>
-                  <Text fontFamily="mono" fontSize="sm" color="white" wordBreak="break-all">
+                  <Text className="mono" fontSize="sm" color="kk.text" wordBreak="break-all">
                     {selectedAddress}
                   </Text>
                 </Box>
-                {pubkeys.length > 1 && <ChevronDownIcon color="whiteAlpha.600" boxSize={5} ml={2} />}
+                {pubkeys.length > 1 && <ChevronDownIcon color="kk.dim" boxSize={5} ml={2} />}
               </Flex>
             </MenuButton>
             {pubkeys.length > 1 && (
-              <MenuList bg="gray.800" borderColor="whiteAlpha.200">
+              <MenuList bg="kk.surfaceHi" borderColor="kk.lineHi">
                 {pubkeys.map((pubkey, index) => {
-                  const addr = pubkey.address || pubkey.master;
+                  const addr = addressForPubkey(pubkey);
                   return (
                     <MenuItem
-                      key={index}
-                      onClick={() => handleAddressSelect(addr)}
-                      bg={selectedAddress === addr ? 'whiteAlpha.200' : 'transparent'}
+                      key={pubkey.note || index}
+                      onClick={() => handleAccountSelect(pubkey, index)}
+                      bg={selectedAddress && selectedAddress === addr ? 'whiteAlpha.100' : 'transparent'}
                       _hover={{ bg: 'whiteAlpha.100' }}>
                       <VStack align="start" spacing={0}>
-                        <Text fontSize="xs" color="whiteAlpha.600">
+                        <Text fontSize="xs" color="kk.faint">
                           {getAddressType(pubkey, index)}
                         </Text>
-                        <Text fontFamily="mono" fontSize="sm">
-                          {formatAddress(addr)}
+                        <Text className="mono" fontSize="sm" color="kk.text">
+                          {addr ? formatAddress(addr) : '…'}
                         </Text>
                       </VStack>
                     </MenuItem>
@@ -454,7 +532,7 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
             aria-label="Copy address"
             icon={hasCopied ? <CheckIcon /> : <CopyIcon />}
             variant="ghost"
-            colorScheme={hasCopied ? 'green' : 'gray'}
+            color={hasCopied ? 'kk.good' : 'kk.dim'}
             size="lg"
             onClick={copyToClipboard}
             ml={2}
@@ -463,7 +541,7 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
       </Box>
 
       {/* Warning */}
-      <Text fontSize="xs" color="whiteAlpha.500" textAlign="center">
+      <Text fontSize="xs" color="kk.faint" textAlign="center">
         Only send {assetContext?.symbol} to this address. Sending other assets may result in permanent loss.
       </Text>
     </VStack>

--- a/pages/side-panel/src/components/Receive.tsx
+++ b/pages/side-panel/src/components/Receive.tsx
@@ -75,19 +75,29 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
         // addresses and the switch handler has something to look up.
         if (isUtxoNetwork(ctxAsset?.networkId) && ctxAsset?.networkId) {
           const allPks = (ctxAsset.pubkeys || []) as any[];
-          allPks.forEach((pk, idx) => {
+          allPks.forEach(pk => {
             if (!pk?.note) return;
             chrome.runtime.sendMessage(
               {
                 type: 'GET_UTXO_ADDRESS',
                 networkId: ctxAsset.networkId,
-                scriptType: pk.scriptType,
+                // Raw pubkeys use snake_case `script_type` (matches the
+                // path config in chainConfig.ts and the SDK request shape
+                // in wallet.ts). Reading `scriptType` here was always
+                // undefined → derivation defaulted to p2pkh, so segwit
+                // and native-segwit accounts were rendered as legacy
+                // addresses.
+                scriptType: pk.script_type,
                 note: pk.note,
               },
               utxoResp => {
                 if (!utxoResp?.address) return;
                 setAddressByNote(prev => ({ ...prev, [pk.note]: utxoResp.address }));
-                if (idx === 0) setSelectedAddress(utxoResp.address);
+                // Don't set selectedAddress here — a separate effect
+                // picks the address that matches the current pubkey
+                // context (header selection), so we avoid pinning to
+                // ctxAsset.pubkeys[0] which is the first configured
+                // path, not the user's chosen account.
               },
             );
           });
@@ -127,13 +137,36 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
     }
   }, [selectedAddress, assetContext?.icon]);
 
+  // Pick the UTXO receive address that matches the current pubkey context
+  // (header account selection). Without this, the page would default to
+  // the first configured path on the network — e.g. legacy BTC even when
+  // the header has Native Segwit selected — because SET_ASSET_CONTEXT
+  // replaces ctxAsset.pubkeys with all network pubkeys and the first one
+  // is whichever happens to be earliest in chainConfig.
+  useEffect(() => {
+    if (!isUtxoNetwork(assetContext?.networkId)) return;
+    const preferredNote = pubkeyContext?.note ?? pubkeys[0]?.note;
+    if (!preferredNote) return;
+    const addr = addressByNote[preferredNote];
+    if (addr && addr !== selectedAddress) setSelectedAddress(addr);
+    // Intentionally omit `selectedAddress` from deps — including it would
+    // re-fire on every set and cause redundant work; we only want to
+    // react to changes in the inputs that determine the address.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pubkeyContext, addressByNote, assetContext?.networkId, pubkeys]);
+
   // Listen for pubkey context updates from other components (like header)
   useEffect(() => {
     const messageListener = (message: any) => {
       if (message.type === 'PUBKEY_CONTEXT_UPDATED' && message.pubkeyContext) {
         setPubkeyContext(message.pubkeyContext);
-        const address = message.pubkeyContext.address || message.pubkeyContext.master;
-        setSelectedAddress(address);
+        // For UTXO chains, the address resolver effect picks the right
+        // entry from addressByNote. Setting it directly here would
+        // briefly stomp the QR with an empty string (UTXO pubkeys have
+        // no .address) before the effect runs.
+        const pc = message.pubkeyContext;
+        const isUtxo = pc.type === 'xpub' || pc.type === 'zpub' || !pc.address;
+        if (!isUtxo) setSelectedAddress(pc.address || pc.master);
       }
     };
 
@@ -156,7 +189,7 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
             {
               type: 'GET_UTXO_ADDRESS',
               networkId: assetContext.networkId,
-              scriptType: pubkey.scriptType,
+              scriptType: pubkey.script_type,
               note: pubkey.note,
             },
             utxoResp => {
@@ -325,7 +358,8 @@ export function Receive({ onClose, balances = [] }: ReceiveProps) {
     }
     if (accountNum === null) accountNum = index;
 
-    const stLabel = pubkey.scriptType ? SCRIPT_TYPE_LABELS[pubkey.scriptType.toLowerCase()] : null;
+    const rawScriptType = pubkey.script_type || pubkey.scriptType;
+    const stLabel = rawScriptType ? SCRIPT_TYPE_LABELS[rawScriptType.toLowerCase()] : null;
     return stLabel ? `Account ${accountNum} · ${stLabel}` : `Account ${accountNum}`;
   };
 

--- a/pages/side-panel/src/components/Settings.tsx
+++ b/pages/side-panel/src/components/Settings.tsx
@@ -171,7 +171,7 @@ const Settings = () => {
   return (
     <VStack spacing={4}>
       {/* More Docs Link - Prominent and on top */}
-      <Link href="https://docs.keepkey.info" isExternal>
+      <Link href="https://docs.keepkey.com" isExternal>
         <Button variant="solid" colorScheme="teal" size="lg" w="100%" mt={4} mb={6}>
           📖 Visit KeepKey Docs
         </Button>

--- a/pages/side-panel/src/components/Tokens.tsx
+++ b/pages/side-panel/src/components/Tokens.tsx
@@ -151,10 +151,24 @@ export const Tokens = ({ asset, networkId }: TokensProps) => {
     }
   };
 
+  // Force a Pioneer /portfolio round-trip rather than just re-reading the
+  // cache. Used by both the header Refresh button and the empty-state
+  // Discover Tokens button — the empty case is the one that actually
+  // matters: if the cold-start auto-flow missed SPL/TRC-20 discovery, a
+  // plain GET_APP_BALANCES would just return the same empty cache. The
+  // background pushes BALANCES_UPDATED on commit, which our useEffect
+  // listener picks up to repaint, so we don't need to setTokens directly
+  // from this response.
   const handleRefresh = async () => {
     setIsRefreshing(true);
-    await fetchTokens();
-    setTimeout(() => setIsRefreshing(false), 1000);
+    try {
+      await new Promise<void>(resolve => {
+        chrome.runtime.sendMessage({ type: 'REFRESH_ALL_BALANCES' }, () => resolve());
+      });
+      await fetchTokens();
+    } finally {
+      setTimeout(() => setIsRefreshing(false), 500);
+    }
   };
 
   const handleTokenClick = (token: any) => {

--- a/pages/side-panel/src/components/header/AccountDropdown.tsx
+++ b/pages/side-panel/src/components/header/AccountDropdown.tsx
@@ -48,40 +48,30 @@ const AccountDropdown: React.FC<AccountDropdownProps> = ({
 
   return (
     <Box position="relative">
-      {/* Trigger — always interactive */}
+      {/* Trigger — single-line to match NetworkDropdown height. Label when
+          we have multiple accounts so the user can tell them apart; short
+          address when we only have one (the label is redundant then). */}
       <Flex
         alignItems="center"
         cursor={hasMultiple ? 'pointer' : 'default'}
         onClick={() => hasMultiple && setIsExpanded(prev => !prev)}
         px={2}
-        py={1}
+        h="32px"
         borderRadius="md"
         bg="whiteAlpha.50"
         _hover={hasMultiple ? { bg: 'whiteAlpha.150' } : {}}
         transition="background 0.15s"
-        minW={0}>
-        <Box minW={0} flex={1}>
-          {hasMultiple && (
-            <Text fontSize="xs" color="whiteAlpha.800" isTruncated maxW="80px">
-              {selected?.label || 'Account'}
-            </Text>
-          )}
-          <Text
-            fontSize="xs"
-            fontFamily="mono"
-            color="whiteAlpha.500"
-            isTruncated
-            maxW="100px"
-            cursor="pointer"
-            _hover={{ color: 'whiteAlpha.800' }}
-            onClick={e => {
-              e.stopPropagation();
-              if (selected?.address) handleCopy(selected.address, selected.key);
-            }}
-            title={selected?.address || ''}>
-            {selected ? formatAddress(selected.address) : ''}
-          </Text>
-        </Box>
+        minW={0}
+        title={selected?.address || ''}>
+        <Text
+          fontSize="xs"
+          fontWeight={hasMultiple ? 'semibold' : 500}
+          color="white"
+          isTruncated
+          maxW="100px"
+          className={hasMultiple ? undefined : 'mono'}>
+          {hasMultiple ? selected?.label || 'Account' : selected ? formatAddress(selected.address) : ''}
+        </Text>
         {!hasMultiple && selected?.address && (
           <IconButton
             icon={copiedKey === selected.key ? <CheckIcon /> : <CopyIcon />}

--- a/pages/side-panel/src/components/header/NetworkDropdown.tsx
+++ b/pages/side-panel/src/components/header/NetworkDropdown.tsx
@@ -104,7 +104,7 @@ const NetworkDropdown: React.FC<NetworkDropdownProps> = ({
         cursor="pointer"
         onClick={() => setIsExpanded(prev => !prev)}
         px={2}
-        py={1}
+        h="32px"
         borderRadius="md"
         bg="whiteAlpha.100"
         _hover={{ bg: 'whiteAlpha.200' }}

--- a/pages/side-panel/src/components/header/headerTypes.ts
+++ b/pages/side-panel/src/components/header/headerTypes.ts
@@ -15,6 +15,12 @@ export interface AccountItem {
   pubkey: any;
   scriptType?: string;
   accountIndex?: number;
+  /** Note from the underlying path config (chainConfig.ts). Unique per
+   *  configured derivation; used as the canonical identity for UTXO
+   *  accounts where (script_type, accountIndex) alone may not be
+   *  unique — BTC has multiple p2wpkh and p2pkh paths across account
+   *  indices. */
+  note?: string;
   /** Human-readable derivation path, e.g. "m/84'/0'/0'" */
   path?: string;
   isDefault: boolean;

--- a/pages/side-panel/src/components/header/headerTypes.ts
+++ b/pages/side-panel/src/components/header/headerTypes.ts
@@ -34,5 +34,6 @@ export interface NetworkAccountHeaderProps {
   isRefreshing: boolean;
   onSettingsOpen: () => void;
   onRefresh: () => void;
+  onHome?: () => void;
   onSelectNetwork?: (asset: any) => void;
 }

--- a/pages/side-panel/src/components/header/headerUtils.ts
+++ b/pages/side-panel/src/components/header/headerUtils.ts
@@ -152,20 +152,52 @@ function buildEvmAccounts(pubkeys: any[], networkId: string, ethAccounts: number
   return items;
 }
 
+// "Bitcoin account 1 Native Segwit (Bech32)" → 1, "Default ATOM path" → null
+function extractAccountIdxFromNote(note?: string): number | null {
+  if (!note) return null;
+  const m = note.match(/account\s*(\d+)/i);
+  return m ? parseInt(m[1], 10) : null;
+}
+
 function buildBtcAccounts(pubkeys: any[]): AccountItem[] {
   const items: AccountItem[] = [];
   const btcPubkeys = pubkeys.filter(pk => (pk.networks || []).includes(BTC_NETWORK_ID) && pk.script_type);
 
+  // Multiple paths can share a script_type (chainConfig has BTC account 0
+  // and account 1 both at p2wpkh, plus several legacy accounts). Track
+  // duplicates so we know whether to suffix the label with the account
+  // index — single-account script types stay clean ("Native SegWit"),
+  // repeats get disambiguated ("Native SegWit · Account 1").
+  const scriptTypeCounts = new Map<string, number>();
   for (const pk of btcPubkeys) {
-    const label = BTC_SCRIPT_LABELS[pk.script_type] || pk.script_type;
+    scriptTypeCounts.set(pk.script_type, (scriptTypeCounts.get(pk.script_type) || 0) + 1);
+  }
+
+  let defaultAssigned = false;
+  for (const pk of btcPubkeys) {
+    const baseLabel = BTC_SCRIPT_LABELS[pk.script_type] || pk.script_type;
+    const accountIdx = extractAccountIdxFromNote(pk.note);
+    const repeats = (scriptTypeCounts.get(pk.script_type) || 0) > 1;
+    const label = repeats && accountIdx !== null ? `${baseLabel} · Account ${accountIdx}` : baseLabel;
+    // Only the first p2wpkh row is the default — flagging every Native
+    // Segwit row as default would let React's selection tracking pick
+    // whichever happened to render first, regardless of account.
+    const isDefault = !defaultAssigned && pk.script_type === 'p2wpkh';
+    if (isDefault) defaultAssigned = true;
+
     const address = pk.address || pk.master || '';
     items.push({
-      key: `btc:${pk.script_type}`,
+      // Key on note (unique per chainConfig path) so React doesn't
+      // collapse two p2wpkh rows into one and so selectedAccountKey
+      // can disambiguate them.
+      key: pk.note ? `btc:${pk.note}` : `btc:${pk.script_type}`,
       label,
       address,
       pubkey: pk,
       scriptType: pk.script_type,
-      isDefault: pk.script_type === 'p2wpkh', // Native SegWit is default
+      accountIndex: accountIdx ?? undefined,
+      note: pk.note,
+      isDefault,
     });
   }
 
@@ -176,15 +208,28 @@ function buildUtxoAccounts(pubkeys: any[], networkId: string): AccountItem[] {
   const items: AccountItem[] = [];
   const relevant = pubkeys.filter(pk => (pk.networks || []).includes(networkId));
 
+  // Same dedup logic as BTC — a non-BTC UTXO chain (LTC) has both
+  // p2pkh and p2wpkh entries, and could grow to multiple of each.
+  const scriptTypeCounts = new Map<string, number>();
   for (const pk of relevant) {
-    const label = pk.script_type ? BTC_SCRIPT_LABELS[pk.script_type] || pk.script_type : 'Default';
+    if (pk.script_type) scriptTypeCounts.set(pk.script_type, (scriptTypeCounts.get(pk.script_type) || 0) + 1);
+  }
+
+  for (const pk of relevant) {
+    const baseLabel = pk.script_type ? BTC_SCRIPT_LABELS[pk.script_type] || pk.script_type : 'Default';
+    const accountIdx = extractAccountIdxFromNote(pk.note);
+    const repeats = pk.script_type ? (scriptTypeCounts.get(pk.script_type) || 0) > 1 : false;
+    const label = repeats && accountIdx !== null ? `${baseLabel} · Account ${accountIdx}` : baseLabel;
+
     const address = pk.address || pk.master || '';
     items.push({
-      key: `utxo:${pk.script_type || 'default'}`,
+      key: pk.note ? `utxo:${pk.note}` : `utxo:${pk.script_type || 'default'}`,
       label,
       address,
       pubkey: pk,
       scriptType: pk.script_type,
+      accountIndex: accountIdx ?? undefined,
+      note: pk.note,
       isDefault: items.length === 0,
     });
   }

--- a/pages/side-panel/src/styles/theme/index.ts
+++ b/pages/side-panel/src/styles/theme/index.ts
@@ -1,7 +1,6 @@
 import { extendTheme } from '@chakra-ui/react';
 import { config } from './config';
 
-// Define the extended KeepKey-themed color palette
 const colors = {
   keepKeyGold: {
     50: '#fffaf0',
@@ -27,7 +26,29 @@ const colors = {
     800: '#0f0f0f',
     900: '#0a0a0a',
   },
+  // Surface tokens lifted from the design handoff (darker, layered).
+  kkSurface: {
+    bg: '#0b0d10',
+    bg2: '#111418',
+    surface: '#161a1f',
+    surfaceHi: '#1c2127',
+    line: 'rgba(255,255,255,0.06)',
+    lineHi: 'rgba(255,255,255,0.10)',
+  },
+  kkText: {
+    base: '#e6e9ef',
+    dim: 'rgba(230,233,239,0.62)',
+    faint: 'rgba(230,233,239,0.38)',
+  },
+  // OKLCH status palette from the handoff (fallback hex for older browsers).
+  kkStatus: {
+    good: '#57ce51',
+    warn: '#e6b955',
+    bad: '#e56a4d',
+  },
 };
+
+const GOLD_GRADIENT = 'linear-gradient(180deg, #d29929 0%, #916419 100%)';
 
 export const theme = extendTheme({
   initialColorMode: 'dark',
@@ -35,23 +56,82 @@ export const theme = extendTheme({
   colors: {
     keepKeyGold: colors.keepKeyGold,
     gray: colors.keepKeyBlack,
+    kkSurface: colors.kkSurface,
+    kkText: colors.kkText,
+    kkStatus: colors.kkStatus,
+  },
+  semanticTokens: {
+    colors: {
+      'kk.bg': colors.kkSurface.bg,
+      'kk.bg2': colors.kkSurface.bg2,
+      'kk.surface': colors.kkSurface.surface,
+      'kk.surfaceHi': colors.kkSurface.surfaceHi,
+      'kk.line': colors.kkSurface.line,
+      'kk.lineHi': colors.kkSurface.lineHi,
+      'kk.text': colors.kkText.base,
+      'kk.dim': colors.kkText.dim,
+      'kk.faint': colors.kkText.faint,
+      'kk.good': colors.kkStatus.good,
+      'kk.warn': colors.kkStatus.warn,
+      'kk.bad': colors.kkStatus.bad,
+      'kk.accent': colors.keepKeyGold[400],
+      'kk.accentDim': 'rgba(210,153,41,0.16)',
+      'kk.accentEdge': 'rgba(210,153,41,0.36)',
+    },
   },
   fonts: {
-    heading: 'Plus Jakarta Sans, sans-serif',
-    body: 'Plus Jakarta Sans, sans-serif',
+    heading: "'Inter', system-ui, sans-serif",
+    body: "'Inter', system-ui, sans-serif",
+    mono: "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+  },
+  styles: {
+    global: {
+      'html, body, #app-container': {
+        background: colors.kkSurface.bg,
+        color: colors.kkText.base,
+        fontFamily: "'Inter', system-ui, sans-serif",
+      },
+      // Uppercase letter-spaced micro-label used throughout the design.
+      '.kk-eyebrow': {
+        fontSize: '10px',
+        letterSpacing: '0.16em',
+        textTransform: 'uppercase',
+        color: colors.kkText.faint,
+        fontWeight: 600,
+      },
+      '.mono': {
+        fontFamily: "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+      },
+    },
   },
   components: {
     Button: {
       baseStyle: {
-        fontWeight: 'bold',
+        fontWeight: 600,
+        letterSpacing: '-0.1px',
+        borderRadius: '10px',
       },
       variants: {
-        solid: (props: any) => ({
-          bg: props.colorMode === 'dark' ? 'keepKeyGold.500' : 'keepKeyGold.400',
-          color: 'white',
+        // Gradient gold with inset highlight + soft gold glow, black label — the design's primary action.
+        solid: () => ({
+          bgImage: GOLD_GRADIENT,
+          bg: 'keepKeyGold.500', // fallback for browsers w/o gradient support
+          color: '#0b0d10',
+          boxShadow: '0 6px 20px -10px rgba(210,153,41,0.9), inset 0 1px 0 rgba(255,255,255,0.25)',
           _hover: {
-            bg: 'keepKeyGold.600',
+            bgImage: GOLD_GRADIENT,
+            filter: 'brightness(1.06)',
+            _disabled: { filter: 'none' },
           },
+          _active: { filter: 'brightness(0.95)' },
+        }),
+        ghost: () => ({
+          bg: 'transparent',
+          color: 'kk.text',
+          border: '1px solid',
+          borderColor: 'kk.lineHi',
+          _hover: { bg: 'kk.surface' },
+          _active: { bg: 'kk.surfaceHi' },
         }),
       },
       defaultProps: {
@@ -59,7 +139,6 @@ export const theme = extendTheme({
         variant: 'solid',
       },
     },
-    // You can extend other components here in a similar fashion
   },
   config,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,15 @@ importers:
       '@extension/storage':
         specifier: workspace:*
         version: link:../packages/storage
+      '@noble/hashes':
+        specifier: ^1.5.0
+        version: 1.8.0
+      '@scure/base':
+        specifier: ^1.1.9
+        version: 1.2.6
+      '@scure/bip32':
+        specifier: ^1.5.0
+        version: 1.7.0
       '@solana/wallet-standard-features':
         specifier: ^1.3.0
         version: 1.3.0
@@ -1332,9 +1341,17 @@ packages:
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/hashes@1.3.2':
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
     engines: {node: '>= 16'}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1581,6 +1598,12 @@ packages:
     resolution: {integrity: sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==}
     cpu: [x64]
     os: [win32]
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -6052,7 +6075,13 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.3.2
 
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/hashes@1.3.2': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6224,6 +6253,14 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.50.0':
     optional: true
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@sec-ant/readable-stream@0.4.1': {}
 


### PR DESCRIPTION
## Summary

Two related fixes for the side-panel UI revamp branch.

### Receive tab — loads without a device round-trip
- Derive UTXO receive addresses locally from the cached xpub (BIP32 + script-type encoding) instead of calling `sdk.address.utxoGetAddress`. Page renders in view-only mode and survives device hot-swaps. Adds `@scure/bip32`, `@scure/base`, `@noble/hashes`; new `chrome-extension/src/background/utxoDerive.ts` covers BTC (legacy / segwit / native segwit), LTC, DOGE, DASH, BCH cashaddr.
- Fix the account-switch dropdown — it looked up pubkeys by `.address || .master`, both empty on UTXO, so clicks were silent no-ops. Now keys by `pubkey.note` and shows real derived addresses instead of truncated xpubs.
- Labels read `Account 0 · Native Segwit` etc. so the three BTC entries that all share account index 0 are distinguishable.
- `GET_UTXO_ADDRESS` match order tightened so `note` wins over `scriptType` (multiple `p2wpkh` accounts can be disambiguated).

### Asset detail layout
- Center `Receive` and `AssetDetail` views vertically (full-height wrappers + biased flex spacers).
- Hide the `Tokens` tab on UTXO chains entirely instead of showing an empty "No tokens for UTXO chains" panel.

### Token auto-discovery race
- Cold-start used three parallel `prefetch().then(fetch(true))` chains (Solana / Tron / TON). Each fetch's snapshot missed pubkeys still being added by the other two prefetches, and the staleness guard at commit time discarded all but the slowest. Result: SPL / TRC-20 tokens silently never landed in `cachedBalances`, and users had to press "Discover Tokens" to see them. Replaced with a single `Promise.allSettled([sol, tron, ton]).then(fetch(true))` so the one committed fetch sees the full pubkey set.
- Wire the Discover/Refresh button to `REFRESH_ALL_BALANCES` so it actually round-trips Pioneer instead of re-reading the cache (it was a placebo before).

## Test plan

- [ ] Reload extension; with no device attached, open Receive on BTC — address renders without a spinner.
- [ ] With device attached, switch the Receive account dropdown; the QR/address updates and the global pubkey context follows.
- [ ] Confirm BTC dropdown labels distinguish `Account 0 · Legacy` / `Segwit` / `Native Segwit`.
- [ ] Open Bitcoin asset detail — Tokens tab is gone, only Activity is shown; layout is centered.
- [ ] Cold-start the extension and open Solana asset detail — SPL tokens appear without pressing any button.
- [ ] Press the Refresh / Discover Tokens button — observe a Pioneer `/portfolio` request fires (network tab) instead of just re-reading cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)