### PR TITLE
feat(ux): risk-tiered approval colors, hex dump + copy, deep-link Chainlist, typed timeouts

### DIFF
--- a/chrome-extension/src/background/chains/solanaHandler.ts
+++ b/chrome-extension/src/background/chains/solanaHandler.ts
@@ -351,7 +351,7 @@ async function signTransactionViaRest(txBase64: string): Promise<{ signature: st
     });
   } catch (e: any) {
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      throw createProviderRpcError(-32603, 'Vault signing timed out');
+      throw createTimeoutError('Vault signing timed out');
     }
     throw createProviderRpcError(-32603, `Vault connection failed: ${e.message}`);
   }
@@ -405,7 +405,7 @@ async function signMessageViaRest(messageBase64: string): Promise<number[]> {
     });
   } catch (e: any) {
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      throw createProviderRpcError(-32603, 'Vault sign-message timed out');
+      throw createTimeoutError('Vault sign-message timed out');
     }
     throw createProviderRpcError(-32603, `Vault connection failed: ${e.message}`);
   }
@@ -466,7 +466,7 @@ async function signOffchainMessageViaRest(
     });
   } catch (e: any) {
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      throw createProviderRpcError(-32603, 'Vault Solana sign-offchain timed out');
+      throw createTimeoutError('Vault Solana sign-offchain timed out');
     }
     throw createProviderRpcError(-32603, `Vault connection failed: ${e.message}`);
   }
@@ -508,7 +508,7 @@ async function broadcastTransaction(signedTxBase64: string): Promise<string> {
     });
   } catch (e: any) {
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      throw createProviderRpcError(-32603, 'Solana RPC broadcast timed out');
+      throw createTimeoutError('Solana RPC broadcast timed out');
     }
     throw createProviderRpcError(-32603, `Solana RPC connection failed: ${e.message}`);
   }

--- a/chrome-extension/src/background/chains/solanaHandler.ts
+++ b/chrome-extension/src/background/chains/solanaHandler.ts
@@ -1,7 +1,7 @@
 import { requestStorage } from '@extension/storage';
 import { v4 as uuidv4 } from 'uuid';
 import * as wallet from '../wallet';
-import { createProviderRpcError } from '../utils';
+import { createProviderRpcError, createTimeoutError } from '../utils';
 import { requireMessageSigningFirmware } from '../firmware';
 
 const TAG = ' | solanaHandler | ';

--- a/chrome-extension/src/background/chains/tonHandler.ts
+++ b/chrome-extension/src/background/chains/tonHandler.ts
@@ -16,7 +16,7 @@
 import { requestStorage } from '@extension/storage';
 import { v4 as uuidv4 } from 'uuid';
 import * as wallet from '../wallet';
-import { createProviderRpcError } from '../utils';
+import { createProviderRpcError, createTimeoutError } from '../utils';
 import { requireMessageSigningFirmware } from '../firmware';
 
 const TAG = ' | tonHandler | ';
@@ -204,7 +204,7 @@ async function buildTransferViaRest(params: {
     });
   } catch (e: any) {
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      throw createProviderRpcError(-32603, 'Vault TON build timed out');
+      throw createTimeoutError('Vault TON build timed out');
     }
     throw createProviderRpcError(-32603, `Vault connection failed: ${e.message}`);
   }
@@ -235,7 +235,7 @@ async function signTransactionViaRest(bodyHashHex: string, toAddress: string, am
     });
   } catch (e: any) {
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      throw createProviderRpcError(-32603, 'Vault TON signing timed out');
+      throw createTimeoutError('Vault TON signing timed out');
     }
     throw createProviderRpcError(-32603, `Vault connection failed: ${e.message}`);
   }
@@ -324,7 +324,7 @@ async function tonSignMessageViaRest(
     });
   } catch (e: any) {
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      throw createProviderRpcError(-32603, 'Vault TON sign-message timed out');
+      throw createTimeoutError('Vault TON sign-message timed out');
     }
     throw createProviderRpcError(-32603, `Vault connection failed: ${e.message}`);
   }
@@ -363,7 +363,7 @@ async function finalizeTransferViaRest(build: any, signature: string): Promise<{
     });
   } catch (e: any) {
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      throw createProviderRpcError(-32603, 'Vault TON finalize timed out');
+      throw createTimeoutError('Vault TON finalize timed out');
     }
     throw createProviderRpcError(-32603, `Vault connection failed: ${e.message}`);
   }

--- a/chrome-extension/src/background/chains/tronHandler.ts
+++ b/chrome-extension/src/background/chains/tronHandler.ts
@@ -1,7 +1,7 @@
 import { requestStorage, assetContextStorage } from '@extension/storage';
 import { v4 as uuidv4 } from 'uuid';
 import * as wallet from '../wallet';
-import { createProviderRpcError } from '../utils';
+import { createProviderRpcError, createTimeoutError } from '../utils';
 import { requireMessageSigningFirmware } from '../firmware';
 
 const TAG = ' | tronHandler | ';
@@ -347,7 +347,7 @@ async function signTronViaRest(
     });
   } catch (e: any) {
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      throw createProviderRpcError(-32603, 'Vault Tron signing timed out');
+      throw createTimeoutError('Vault Tron signing timed out');
     }
     throw createProviderRpcError(-32603, `Vault connection failed: ${e.message}`);
   }
@@ -410,7 +410,7 @@ async function tronSignMessageViaRest(
     });
   } catch (e: any) {
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      throw createProviderRpcError(-32603, 'Vault Tron sign-message timed out');
+      throw createTimeoutError('Vault Tron sign-message timed out');
     }
     throw createProviderRpcError(-32603, `Vault connection failed: ${e.message}`);
   }
@@ -485,7 +485,7 @@ async function tronSignTypedHashViaRest(
     });
   } catch (e: any) {
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      throw createProviderRpcError(-32603, 'Vault Tron sign-typed-hash timed out');
+      throw createTimeoutError('Vault Tron sign-typed-hash timed out');
     }
     throw createProviderRpcError(-32603, `Vault connection failed: ${e.message}`);
   }

--- a/chrome-extension/src/background/methods.ts
+++ b/chrome-extension/src/background/methods.ts
@@ -257,10 +257,15 @@ export const handleWalletRequest = async (
     errorMessage = formatUserError({ message: errorMessage });
 
     //push error to the popup
+    // Forward `kind` so the side panel can render category-specific UI
+    // (e.g. friendly retry card for timeouts) without regex-matching
+    // the message.
+    const kind = (error as ProviderRpcError).kind;
     chrome.runtime.sendMessage({
       action: 'transaction_error',
       eventId: requestInfo?.id,
       error: errorMessage,
+      kind,
     });
 
     if ((error as ProviderRpcError).code && (error as ProviderRpcError).message) {

--- a/chrome-extension/src/background/utils.ts
+++ b/chrome-extension/src/background/utils.ts
@@ -1,14 +1,32 @@
+/**
+ * Categorical hint for the side panel — lets the UI key off a stable
+ * field instead of regex-matching `message`. Add cases as we identify
+ * other error categories worth distinct UI treatment.
+ */
+export type ProviderErrorKind = 'timeout';
+
 export interface ProviderRpcError extends Error {
   code: number;
   data?: unknown;
+  kind?: ProviderErrorKind;
 }
 
-export const createProviderRpcError = (code: number, message: string, data?: unknown): ProviderRpcError => {
+export const createProviderRpcError = (
+  code: number,
+  message: string,
+  data?: unknown,
+  kind?: ProviderErrorKind,
+): ProviderRpcError => {
   const error = new Error(message) as ProviderRpcError;
   error.code = code;
   if (data) error.data = data;
+  if (kind) error.kind = kind;
   return error;
 };
+
+/** Convenience for timeout errors so callers don't have to remember the kind string. */
+export const createTimeoutError = (message: string): ProviderRpcError =>
+  createProviderRpcError(-32603, message, undefined, 'timeout');
 
 /**
  * Translate vault SdkError ("No device connected") into a user-facing message.

--- a/pages/side-panel/src/approval/ChainNotEnabledCard.tsx
+++ b/pages/side-panel/src/approval/ChainNotEnabledCard.tsx
@@ -1,6 +1,7 @@
 import { Button, Card, Box, Flex, Stack, Text, Heading, Icon, Divider, Link } from '@chakra-ui/react';
 import { ExternalLinkIcon, WarningTwoIcon } from '@chakra-ui/icons';
 import { requestStorage } from '@extension/storage';
+import { KNOWN_EVM_CHAINS } from '../components/header/headerConstants';
 
 /**
  * Surface for a wallet_switchEthereumChain request that hit a chain we
@@ -17,7 +18,13 @@ import { requestStorage } from '@extension/storage';
 export default function ChainNotEnabledCard({ event, onDismiss }: { event: any; onDismiss: () => void }) {
   const chainIdHex: string = event?.unsignedTx?.chainIdHex || '?';
   const chainIdDecimal: number | string = event?.unsignedTx?.chainIdDecimal ?? '?';
+  const networkId: string = event?.networkId || event?.unsignedTx?.networkId || '';
   const siteUrl: string = event?.siteUrl || event?.href || '';
+
+  // If this is one of the chains the network dropdown advertises, show
+  // its name rather than just a hex/decimal pair — far less scary for
+  // a user trying to figure out what their dApp asked for.
+  const knownName = KNOWN_EVM_CHAINS[networkId]?.name;
 
   const close = async () => {
     try {
@@ -33,7 +40,14 @@ export default function ChainNotEnabledCard({ event, onDismiss }: { event: any; 
   };
 
   const openChainlist = () => {
-    window.open('https://chainlist.org/', '_blank');
+    // Deep-link by chainId so the user lands on the row for the requested
+    // chain instead of having to scroll the full Chainlist catalog.
+    const search = typeof chainIdDecimal === 'number' ? chainIdDecimal : String(chainIdDecimal);
+    const url =
+      search && search !== '?'
+        ? `https://chainlist.org/?search=${encodeURIComponent(search)}`
+        : 'https://chainlist.org/';
+    window.open(url, '_blank');
   };
 
   return (
@@ -61,9 +75,20 @@ export default function ChainNotEnabledCard({ event, onDismiss }: { event: any; 
             <Text fontSize="xs" color="whiteAlpha.600" mb={1}>
               Requested chain
             </Text>
-            <Text fontFamily="mono" fontSize="sm">
-              {chainIdHex} ({chainIdDecimal})
-            </Text>
+            {knownName ? (
+              <>
+                <Text fontSize="sm" fontWeight="medium">
+                  {knownName}
+                </Text>
+                <Text fontFamily="mono" fontSize="xs" color="whiteAlpha.600">
+                  {chainIdHex} ({chainIdDecimal})
+                </Text>
+              </>
+            ) : (
+              <Text fontFamily="mono" fontSize="sm">
+                {chainIdHex} ({chainIdDecimal})
+              </Text>
+            )}
           </Box>
 
           <Divider />

--- a/pages/side-panel/src/approval/Transaction.tsx
+++ b/pages/side-panel/src/approval/Transaction.tsx
@@ -37,6 +37,9 @@ const Transaction = ({
   const [awaitingDeviceApproval, setAwaitingDeviceApproval] = useState<boolean>(false);
   const [transactionInProgress, setTransactionInProgress] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // Categorical hint forwarded from the background so we can render
+  // category-specific UI (e.g. timeout) without regex-matching `message`.
+  const [errorKind, setErrorKind] = useState<string | null>(null);
   const [showTxidPage, setShowTxidPage] = useState<boolean>(false);
   const [assetContext, setAssetContext] = useState<any>(null); // Local state for asset context
   const [explorerUrl, setExplorerUrl] = useState<string | null>(null);
@@ -186,6 +189,7 @@ const Transaction = ({
         } else {
           // Show error for other types of failures
           setErrorMessage(errorText);
+          setErrorKind(typeof message.kind === 'string' ? message.kind : null);
           setTransactionInProgress(false);
         }
       }
@@ -283,18 +287,23 @@ const Transaction = ({
   }
 
   if (errorMessage) {
-    // Treat "timed out" as a soft retryable state, not a fatal error.
-    // The device is fine, the dApp request is just one-shot — the user
-    // re-initiates from the dApp page. Loud red copy made this feel like
-    // something broke.
-    const isTimeout = /timed out|timeout/i.test(errorMessage);
+    // Treat timeouts as a soft retryable state, not a fatal error. The
+    // device is fine, the dApp request is just one-shot — the user has
+    // to reject and re-initiate from the dApp page. Loud red copy made
+    // this feel like something broke.
+    //
+    // Categorization comes from the typed `kind` forwarded by the
+    // background. A regex on `errorMessage` is the legacy fallback and
+    // exists only so older builds in the wild (or paths that haven't
+    // adopted createTimeoutError yet) still show the friendlier card.
+    const isTimeout = errorKind === 'timeout' || /timed out|timeout/i.test(errorMessage);
     const status = isTimeout ? 'warning' : 'error';
     const heading = isTimeout ? 'Took too long' : 'Error Occurred';
     const body = isTimeout
-      ? 'No response from your KeepKey in time. You can close this and try the request again from the dApp.'
+      ? 'No response from your KeepKey in time. Reject the request in the dApp, then try again.'
       : errorMessage;
     const buttonScheme = isTimeout ? 'yellow' : 'red';
-    const buttonLabel = isTimeout ? 'Close' : 'Close';
+    const buttonLabel = 'Close';
     return (
       <Flex direction="column" height="100vh" alignItems="center" justifyContent="center" p={6}>
         <Alert

--- a/pages/side-panel/src/approval/other/RequestDetailsCard.tsx
+++ b/pages/side-panel/src/approval/other/RequestDetailsCard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { Box, Divider, Flex, Table, Tbody, Tr, Td, Badge, Avatar } from '@chakra-ui/react';
+import { Box, Divider, Flex, Table, Tbody, Tr, Td, Badge, Avatar, IconButton, Tooltip } from '@chakra-ui/react';
+import { CopyIcon, CheckIcon } from '@chakra-ui/icons';
 
 /**
  * Format a raw integer-string amount into a human-readable decimal using
@@ -37,6 +38,23 @@ function formatAmount(amountRaw: unknown, decimals: number): string {
  * that. If decoding produces a control-character soup, fall back to
  * a hex dump so the user at least sees what's being signed.
  */
+/**
+ * Group bytes for human-readable hex display: 8 bytes per chunk (space
+ * between), 4 chunks per line (newline). One unbroken hex string is
+ * unreadable past ~80 chars; this is how every hex dump tool (xxd,
+ * hexdump -C) formats output for the same reason.
+ */
+function formatHexDump(bytes: number[]): string {
+  const out: string[] = [];
+  for (let i = 0; i < bytes.length; i++) {
+    out.push((bytes[i] & 0xff).toString(16).padStart(2, '0'));
+    if (i % 32 === 31) out.push('\n');
+    else if (i % 8 === 7) out.push('  ');
+    else out.push(' ');
+  }
+  return out.join('').trimEnd();
+}
+
 function decodeMessage(bytes: number[] | undefined): { text: string; isPrintable: boolean } {
   if (!bytes || !Array.isArray(bytes) || bytes.length === 0) {
     return { text: '(empty message)', isPrintable: true };
@@ -51,18 +69,33 @@ function decodeMessage(bytes: number[] | undefined): { text: string; isPrintable
       else if (c === 0xfffd) bad++;
     }
     if (bad / Math.max(text.length, 1) > 0.1) {
-      const hex = bytes.map(b => (b & 0xff).toString(16).padStart(2, '0')).join('');
-      return { text: hex, isPrintable: false };
+      return { text: formatHexDump(bytes), isPrintable: false };
     }
     return { text, isPrintable: true };
   } catch {
-    const hex = bytes.map(b => (b & 0xff).toString(16).padStart(2, '0')).join('');
-    return { text: hex, isPrintable: false };
+    return { text: formatHexDump(bytes), isPrintable: false };
   }
+}
+
+/**
+ * Pretty-print a stashed hex string (no spacing) into the same grouped
+ * dump format `decodeMessage` produces for byte arrays. Used when the
+ * handler has already pre-encoded the message as hex (off-chain path).
+ */
+function regroupHexString(hex: string): string {
+  const clean = hex.replace(/\s+/g, '');
+  const bytes: number[] = [];
+  for (let i = 0; i + 1 < clean.length; i += 2) {
+    const v = parseInt(clean.slice(i, i + 2), 16);
+    if (!Number.isFinite(v)) return hex; // unparseable — return original
+    bytes.push(v);
+  }
+  return bytes.length > 0 ? formatHexDump(bytes) : hex;
 }
 
 export default function RequestDetailsCard({ transaction }: any) {
   const [assetContext, setAssetContext] = useState<any>(null);
+  const [messageCopied, setMessageCopied] = useState(false);
 
   // Function to get asset context
   const requestAssetContext = () => {
@@ -134,7 +167,9 @@ export default function RequestDetailsCard({ transaction }: any) {
       messageText = stashedUtf8;
       isPrintable = true;
     } else if (typeof stashedHex === 'string' && stashedHex.length > 0) {
-      messageText = stashedHex;
+      // Re-format the handler's compact hex into a hex dump so it's
+      // readable rather than one ~2000-char block.
+      messageText = regroupHexString(stashedHex);
       isPrintable = false;
     } else {
       const messageBytes: number[] | undefined = transaction?.request?.[0];
@@ -142,17 +177,37 @@ export default function RequestDetailsCard({ transaction }: any) {
       messageText = decoded.text;
       isPrintable = decoded.isPrintable;
     }
+    const copyMessage = () => {
+      navigator.clipboard
+        .writeText(messageText)
+        .then(() => {
+          setMessageCopied(true);
+          setTimeout(() => setMessageCopied(false), 1500);
+        })
+        .catch(err => console.warn('Failed to copy message:', err));
+    };
     return (
       <Flex direction="column" mb={4}>
         <Box mb={2}>
-          <Badge mb={2}>Message:</Badge>
+          <Flex align="center" justify="space-between" mb={2}>
+            <Badge>Message:</Badge>
+            <Tooltip label={messageCopied ? 'Copied' : 'Copy message'} fontSize="xs">
+              <IconButton
+                aria-label="Copy message"
+                size="xs"
+                variant="ghost"
+                icon={messageCopied ? <CheckIcon color="green.300" /> : <CopyIcon />}
+                onClick={copyMessage}
+              />
+            </Tooltip>
+          </Flex>
           <Box
             p={3}
             borderWidth={1}
             borderRadius="md"
             borderColor="whiteAlpha.300"
             bg="whiteAlpha.50"
-            maxHeight="240px"
+            maxHeight="360px"
             overflowY="auto"
             whiteSpace="pre-wrap"
             wordBreak="break-word"
@@ -162,7 +217,7 @@ export default function RequestDetailsCard({ transaction }: any) {
           </Box>
           {!isPrintable && (
             <Box mt={2} fontSize="xs" color="orange.300">
-              Bytes are not printable UTF-8 — shown in hex.
+              Bytes are not printable UTF-8 — shown as hex dump.
             </Box>
           )}
         </Box>

--- a/pages/side-panel/src/approval/other/RequestMethodCard.tsx
+++ b/pages/side-panel/src/approval/other/RequestMethodCard.tsx
@@ -36,34 +36,40 @@ const getMethodInfo = (txType: string, kind?: string) => {
         icon: <InfoIcon boxSize={8} />,
         color: 'yellow.500',
       };
+    // Color tiering encodes risk:
+    //   blue     — read-only signature, no funds at risk
+    //   orange   — signs a transaction; the dApp still has to broadcast
+    //   red      — signs AND broadcasts (irreversible the moment the user approves)
     case 'solana_signMessage':
       return {
         title: 'Sign Solana Message',
-        description: 'The dApp is asking your KeepKey to sign a message. No funds will move.',
+        description: 'The dApp wants your KeepKey to sign a message. No funds will move.',
         icon: <EditIcon boxSize={8} />,
-        color: 'teal.300',
+        color: 'blue.300',
       };
     case 'solana_signOffchainMessage':
       return {
         title: 'Sign Solana Off-chain Message',
         description:
-          'Domain-separated off-chain envelope. The signature is over a Solana-defined wrapper, not the bare bytes.',
+          'Some apps require this format for off-chain logins. Verify the message text matches what you expect.',
         icon: <EditIcon boxSize={8} />,
-        color: 'teal.300',
+        color: 'blue.300',
       };
     case 'solana_signTransaction':
       return {
         title: 'Sign Solana Transaction',
-        description: 'Review the transaction details on your KeepKey before approving.',
+        description:
+          'Review the transaction details on your KeepKey before approving. The dApp will broadcast after you sign.',
         icon: <CheckCircleIcon boxSize={8} />,
-        color: 'teal.300',
+        color: 'orange.400',
       };
     case 'solana_signAndSendTransaction':
       return {
         title: 'Sign & Send Solana Transaction',
-        description: 'Your KeepKey will sign, then this transaction will be broadcast to Solana.',
-        icon: <CheckCircleIcon boxSize={8} />,
-        color: 'teal.300',
+        description:
+          'Your KeepKey will sign and this transaction will be broadcast immediately. This action is irreversible.',
+        icon: <WarningIcon boxSize={8} />,
+        color: 'red.400',
       };
     default:
       return {


### PR DESCRIPTION
## Summary

UX polish on the approval surfaces shipped in #57.

- **Risk-tiered colors** in the Solana sign-method card. `signMessage` / `signOffchainMessage` are blue (read-only, no funds at risk). `signTransaction` is orange (you sign; the dApp broadcasts). `signAndSendTransaction` is red with a warning icon (signs and broadcasts immediately — irreversible).
- **User-facing copy** for off-chain messages — replaces "the signature is over a Solana-defined wrapper, not the bare bytes" with "Some apps require this format for off-chain logins. Verify the message text matches what you expect."
- **Chainlist deep-link** by chainId — `chainlist.org/?search=56` lands on BSC's row instead of dumping the user on the homepage.
- **Known chain names** on the not-enabled card — shows "BNB Smart Chain" above "0x38 (56)" when the chain is in `KNOWN_EVM_CHAINS`. Stranger chainIds still fall back to mono hex.
- **Hex dump formatting** — non-printable message bytes now render as 8-byte chunks with newlines every 32 bytes, matching `xxd` / `hexdump -C` conventions instead of one unbroken hex string.
- **Copy-to-clipboard** icon next to "Message:" with a 1.5s green checkmark on success. Lets SIWS users paste the message into a verifier.
- **Typed timeout error** — new `createTimeoutError` helper sets `kind: 'timeout'` on the thrown error; `methods.ts` forwards it on `transaction_error`; `Transaction.tsx` keys off `errorKind === 'timeout'` instead of regex-matching the message string. Regex retained as a legacy fallback. Solana, TON, and Tron timeout sites all converted (~10 call sites).
- **Better timeout copy** — "Reject the request in the dApp, then try again." (Old copy didn't tell the user what action to take.)
- Sign-message message box max-height bumped 240→360px for typical SIWS messages.

## Files

- `chrome-extension/src/background/utils.ts` — `ProviderErrorKind`, `createTimeoutError`
- `chrome-extension/src/background/methods.ts` — forward `kind` on `transaction_error`
- `chrome-extension/src/background/chains/{solana,ton,tron}Handler.ts` — use `createTimeoutError` at all 9 timeout throw sites
- `pages/side-panel/src/approval/Transaction.tsx` — `errorKind` state, `kind`-based timeout detection, clearer copy
- `pages/side-panel/src/approval/ChainNotEnabledCard.tsx` — known-name lookup, deep-link Chainlist
- `pages/side-panel/src/approval/other/RequestMethodCard.tsx` — risk-tiered colors + revised copy
- `pages/side-panel/src/approval/other/RequestDetailsCard.tsx` — hex dump formatting, copy button, larger box

## Test plan

- [ ] dApp `signMessage` from a Solana site (e.g. SIWS login) — card is blue, message readable, copy button works (icon turns green for ~1.5s)
- [ ] dApp `signTransaction` from a Solana site — card is orange
- [ ] dApp `signAndSendTransaction` — card is red with warning icon
- [ ] Trigger a sign-message timeout (decline on device for >5min) — yellow "Took too long" card appears with "Reject the request in the dApp, then try again."
- [ ] Switch to a chain Pioneer doesn't know (e.g. invented chainId `0xfffffe`) — chain-not-enabled card shows the chainId; Chainlist link opens `chainlist.org/?search=<decimal>`
- [ ] Switch to a chain in `KNOWN_EVM_CHAINS` but not yet provisioned — card shows "BNB Smart Chain" above the hex/decimal pair
- [ ] Sign a message that decodes to non-UTF-8 bytes — fallback renders as a readable hex dump (8 bytes per chunk, newlines every 32)
- [ ] Existing BSC switch flow from #57 still works (no regression on the typed-timeout refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)