### PR TITLE
fix(eth): RPC failover on broadcast + pin networks on JsonRpcProvider

### DIFF
--- a/chrome-extension/src/background/chains/ethereumHandler.ts
+++ b/chrome-extension/src/background/chains/ethereumHandler.ts
@@ -147,11 +147,16 @@ const getProvider = async (): Promise<JsonRpcProvider> => {
       const cleanUrl = rpcUrl.trim();
       console.log(tag, `Trying RPC [${availableRpcs.indexOf(rpcUrl) + 1}/${availableRpcs.length}]:`, cleanUrl);
 
-      const provider = makeStaticProvider(cleanUrl, currentProvider.networkId || currentProvider.chainId);
-
-      // Test the connection with a quick call (with timeout)
-      const timeoutPromise = new Promise((_, reject) => setTimeout(() => reject(new Error('RPC timeout')), 5000));
-      const blockNumber = await Promise.race([provider.getBlockNumber(), timeoutPromise]);
+      // 5s transport-level timeout (FetchRequest) is the real fix —
+      // without it the awaited promise can race-out at the application
+      // layer while ethers' internal retry loop keeps the abandoned
+      // request alive (and re-tries on backoff). With timeoutMs the
+      // transport itself aborts at 5s, so the outer Promise.race is
+      // redundant.
+      const provider = makeStaticProvider(cleanUrl, currentProvider.networkId || currentProvider.chainId, {
+        timeoutMs: 5000,
+      });
+      const blockNumber = await provider.getBlockNumber();
 
       console.log(tag, '✅ RPC working! Block:', blockNumber, 'URL:', cleanUrl);
 
@@ -1158,7 +1163,10 @@ const signTransaction = async (transaction: any, KEEPKEY_WALLET: any) => {
     if (!transaction.to) throw createProviderRpcError(4000, 'Invalid transaction: missing to');
     if (!transaction.chainId) throw createProviderRpcError(4000, 'Invalid transaction: missing chainId');
 
-    const provider = await getProvider();
+    // Each preflight RPC call is wrapped in withRpcFailover so a
+    // rate-limited URL doesn't break signing before broadcast can help.
+    // Calls are independent; nonce / gas / fee don't have to come from
+    // the same RPC — any working candidate is fine.
 
     let nonce;
     if (!transaction.nonce) {
@@ -1168,7 +1176,9 @@ const signTransaction = async (transaction: any, KEEPKEY_WALLET: any) => {
       // EIP-1559's replacement-underpriced rule (need +10% on both fees),
       // and silently sit in mempool until evicted. That's exactly the
       // "pending forever, eth_getTransactionByHash returns null" symptom.
-      nonce = await provider.getTransactionCount(transaction.from, 'pending');
+      nonce = await withRpcFailover(p => p.getTransactionCount(transaction.from, 'pending'), {
+        tag: tag + ' nonce',
+      });
       transaction.nonce = '0x' + nonce.toString(16);
     }
 
@@ -1189,11 +1199,15 @@ const signTransaction = async (transaction: any, KEEPKEY_WALLET: any) => {
           data: transaction.data,
         });
 
-        let estimatedGas: any = await provider.estimateGas({
-          from: transaction.from,
-          to: transaction.to,
-          data: transaction.data,
-        });
+        let estimatedGas: any = await withRpcFailover(
+          p =>
+            p.estimateGas({
+              from: transaction.from,
+              to: transaction.to,
+              data: transaction.data,
+            }),
+          { tag: tag + ' estimateGas' },
+        );
 
         console.log(tag, 'Estimated gas:', estimatedGas.toString());
 
@@ -1247,7 +1261,7 @@ const signTransaction = async (transaction: any, KEEPKEY_WALLET: any) => {
       input.gasPrice = transaction.gasPrice;
     } else {
       // Fetch fee data if not provided
-      const feeData = await provider.getFeeData();
+      const feeData = await withRpcFailover(p => p.getFeeData(), { tag: tag + ' feeData' });
       input.gasPrice = feeData.gasPrice ? '0x' + feeData.gasPrice.toString(16) : undefined;
     }
 
@@ -1464,6 +1478,135 @@ const mapDefinitiveError = (msg: string): ProviderRpcError => {
   return createProviderRpcError(4000, `Error broadcasting transaction: ${msg}`);
 };
 
+/**
+ * Build the prioritized RPC candidate list for the active EVM provider.
+ * Pioneer-discovered URLs always come first; hardcoded last-resort URLs
+ * are appended (so a stale entry can never preempt a live Pioneer
+ * node); duplicates are removed; URLs in the failedRpcs cooldown are
+ * skipped (or all-cleared if every candidate is cooling).
+ *
+ * Shared by broadcastTransaction and withRpcFailover so both paths
+ * obey the same priority + cooldown semantics.
+ */
+async function getCandidateRpcs(): Promise<{
+  availableRpcs: string[];
+  networkId: string;
+  chainIdRaw: string | number;
+}> {
+  const currentProvider = await web3ProviderStorage.getWeb3Provider();
+  if (!currentProvider) {
+    throw createProviderRpcError(4900, 'Provider not configured');
+  }
+
+  const networkId: string =
+    currentProvider.networkId ||
+    (parseChainId(currentProvider.chainId) != null ? `eip155:${parseChainId(currentProvider.chainId)}` : '');
+
+  const pioneerUrls: string[] =
+    currentProvider.providers && currentProvider.providers.length > 0
+      ? currentProvider.providers
+      : currentProvider.providerUrl
+        ? [currentProvider.providerUrl]
+        : [];
+  const lastResort = networkId ? getLastResortRpcs(networkId) : [];
+
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+  for (const u of [...pioneerUrls, ...lastResort]) {
+    const t = (u || '').trim();
+    if (t && !seen.has(t)) {
+      seen.add(t);
+      candidates.push(t);
+    }
+  }
+  if (candidates.length === 0) {
+    throw createProviderRpcError(4900, 'No RPC URLs available');
+  }
+
+  const now = Date.now();
+  for (const [url, failedAt] of failedRpcs) {
+    if (now - failedAt >= RPC_RETRY_DELAY) failedRpcs.delete(url);
+  }
+  let availableRpcs = candidates.filter(url => {
+    const failedAt = failedRpcs.get(url);
+    return !(failedAt && now - failedAt < RPC_RETRY_DELAY);
+  });
+  if (availableRpcs.length === 0) {
+    failedRpcs.clear();
+    availableRpcs = candidates.slice();
+  }
+
+  return { availableRpcs, networkId, chainIdRaw: currentProvider.chainId };
+}
+
+/**
+ * Heuristic: is this RPC error worth retrying against a different URL?
+ * Used by withRpcFailover (read calls). Broadcast has its own
+ * classifier because it has additional tx-level definitive cases
+ * (insufficient funds, nonce too low, etc.).
+ */
+const isTransientRpcError = (errMsg: string): boolean => {
+  const m = errMsg.toLowerCase();
+  return (
+    m.includes('rate limit') ||
+    m.includes('throttle') ||
+    m.includes('429') ||
+    m.includes('timeout') ||
+    m.includes('econnreset') ||
+    m.includes('etimedout') ||
+    m.includes('network') ||
+    m.includes('server_error') ||
+    m.includes('exceeded maximum retry') ||
+    /\b5\d{2}\b/.test(m) // 5xx HTTP code
+  );
+};
+
+/**
+ * Run a read-style RPC call across the failover candidate list. Used
+ * for preflight calls (nonce, gas estimate, fee data) where any working
+ * RPC will do. Definitive errors (revert, invalid params, ABI errors)
+ * surface immediately — they'll fail the same way on every RPC.
+ * Transient errors (rate-limit, 5xx, network) fall through to the next.
+ *
+ * Each attempt gets a fresh pinned-network provider with a per-HTTP
+ * timeout via FetchRequest, so a hung URL doesn't stall the loop.
+ */
+async function withRpcFailover<T>(
+  op: (provider: JsonRpcProvider, url: string) => Promise<T>,
+  options?: { timeoutMs?: number; tag?: string },
+): Promise<T> {
+  const tag = (options?.tag ?? TAG) + ' | withRpcFailover | ';
+  const { availableRpcs, networkId, chainIdRaw } = await getCandidateRpcs();
+  const errors: { url: string; error: string }[] = [];
+  let lastTransientError: any = null;
+  const now = Date.now();
+  for (const url of availableRpcs) {
+    try {
+      const provider = makeStaticProvider(url, networkId || chainIdRaw, {
+        timeoutMs: options?.timeoutMs ?? 5000,
+      });
+      return await op(provider, url);
+    } catch (e: any) {
+      const errMsg = String(e?.message || e);
+      if (!isTransientRpcError(errMsg)) {
+        // Definitive (revert, invalid params, etc.) — won't help to
+        // try another RPC. Surface to caller.
+        throw e;
+      }
+      console.warn(tag, `RPC ${url} transient failure, trying next:`, errMsg);
+      errors.push({ url, error: errMsg });
+      failedRpcs.set(url, now);
+      lastTransientError = e;
+    }
+  }
+  console.error(tag, 'All RPC endpoints failed:', errors);
+  if (lastTransientError) throw lastTransientError;
+  throw createProviderRpcError(
+    4900,
+    `All ${availableRpcs.length} RPC endpoints failed: ${errors[errors.length - 1]?.error || 'unknown'}`,
+  );
+}
+
 const broadcastTransaction = async (signedTx: string, expectedFrom?: string) => {
   const tag = TAG + ' | broadcastTransaction | ';
 
@@ -1505,55 +1648,9 @@ const broadcastTransaction = async (signedTx: string, expectedFrom?: string) => 
     throw createProviderRpcError(4000, msg);
   }
 
-  // ---- Build candidate URL list ----
-  // Pioneer-discovered URLs always win priority. The hardcoded
-  // last-resort list is appended at the END (see lastResortRpcs.ts) so
-  // it can never preempt a working live node.
-  const currentProvider = await web3ProviderStorage.getWeb3Provider();
-  if (!currentProvider) {
-    throw createProviderRpcError(4900, 'Provider not configured for broadcast');
-  }
-  const networkId: string =
-    currentProvider.networkId ||
-    (parseChainId(currentProvider.chainId) != null ? `eip155:${parseChainId(currentProvider.chainId)}` : '');
-
-  const pioneerUrls: string[] =
-    currentProvider.providers && currentProvider.providers.length > 0
-      ? currentProvider.providers
-      : currentProvider.providerUrl
-        ? [currentProvider.providerUrl]
-        : [];
-  const lastResort = networkId ? getLastResortRpcs(networkId) : [];
-
-  const seen = new Set<string>();
-  const candidates: string[] = [];
-  for (const u of [...pioneerUrls, ...lastResort]) {
-    const t = (u || '').trim();
-    if (t && !seen.has(t)) {
-      seen.add(t);
-      candidates.push(t);
-    }
-  }
-  if (candidates.length === 0) {
-    throw createProviderRpcError(4900, 'No RPC URLs available for broadcast');
-  }
-
-  // Skip URLs in the recent-failure cooldown unless every candidate is
-  // cooling — in that case clear and try the whole set. Same convention
-  // as getProvider.
+  // ---- Build candidate URL list (Pioneer + last-resort, dedup, cooldown) ----
+  const { availableRpcs, networkId, chainIdRaw } = await getCandidateRpcs();
   const now = Date.now();
-  for (const [url, failedAt] of failedRpcs) {
-    if (now - failedAt >= RPC_RETRY_DELAY) failedRpcs.delete(url);
-  }
-  let availableRpcs = candidates.filter(url => {
-    const failedAt = failedRpcs.get(url);
-    return !(failedAt && now - failedAt < RPC_RETRY_DELAY);
-  });
-  if (availableRpcs.length === 0) {
-    console.warn(tag, 'All candidate RPCs in cooldown — clearing and retrying');
-    failedRpcs.clear();
-    availableRpcs = candidates.slice();
-  }
 
   // ---- Failover loop ----
   const errors: { url: string; error: string }[] = [];
@@ -1564,7 +1661,7 @@ const broadcastTransaction = async (signedTx: string, expectedFrom?: string) => 
       // 429/dead URL doesn't stall the failover loop. ethers' default
       // FetchRequest retries 429/5xx with exponential backoff for ~30s,
       // which is exactly the lag this loop is meant to eliminate.
-      const provider = makeStaticProvider(url, networkId || currentProvider.chainId, { timeoutMs: 4000 });
+      const provider = makeStaticProvider(url, networkId || chainIdRaw, { timeoutMs: 4000 });
       const txResponse = await provider.broadcastTransaction(signedTx);
       console.log(
         `[HANDOFF] RPC → BEX (broadcast success) hash=${txResponse?.hash} url=${url} from=${txResponse?.from} nonce=${txResponse?.nonce}`,

--- a/chrome-extension/src/background/chains/ethereumHandler.ts
+++ b/chrome-extension/src/background/chains/ethereumHandler.ts
@@ -16,7 +16,8 @@ import { ChainToNetworkId, caipToNetworkId, networkIdToIcon } from '../chainConf
 import * as wallet from '../wallet';
 import { buildFeeWarning, type FeeChoice, type FeeWarning } from './feeFloors';
 import { openSidePanel, setApprovalBadge } from '../popup';
-import { getChainInfo } from './registry';
+import { getChainInfo, makeStaticProvider } from './registry';
+import { getLastResortRpcs } from './lastResortRpcs';
 
 const TAG = ' | ethereumHandler | ';
 const DOMAIN_WHITE_LIST = [];
@@ -146,7 +147,7 @@ const getProvider = async (): Promise<JsonRpcProvider> => {
       const cleanUrl = rpcUrl.trim();
       console.log(tag, `Trying RPC [${availableRpcs.indexOf(rpcUrl) + 1}/${availableRpcs.length}]:`, cleanUrl);
 
-      const provider = new JsonRpcProvider(cleanUrl);
+      const provider = makeStaticProvider(cleanUrl, currentProvider.networkId || currentProvider.chainId);
 
       // Test the connection with a quick call (with timeout)
       const timeoutPromise = new Promise((_, reject) => setTimeout(() => reject(new Error('RPC timeout')), 5000));
@@ -1414,86 +1415,202 @@ if (typeof chrome !== 'undefined' && chrome.alarms?.onAlarm) {
   });
 }
 
+/**
+ * Classify a broadcast error so the failover loop knows whether to try
+ * the next RPC or stop and surface it.
+ *
+ *  - 'definitive'  → the tx itself is rejected. Trying another RPC will
+ *                    only return the same answer. Stop and surface.
+ *  - 'already-known' → the tx is already in mempool somewhere. Treat as
+ *                    success; pull the hash from the bytes.
+ *  - 'transient'   → rate limit / network / 5xx — retry next URL.
+ */
+type BroadcastErrorKind = 'definitive' | 'already-known' | 'transient';
+const classifyBroadcastError = (msg: string): BroadcastErrorKind => {
+  const m = msg.toLowerCase();
+  // RPC says "we already have this hash" — tx is in mempool. Success.
+  if (m.includes('already known') || m.includes('already in mempool') || m.includes('transaction already in pool'))
+    return 'already-known';
+  // Tx-level rejections — same outcome on any RPC.
+  if (
+    m.includes('insufficient funds') ||
+    m.includes('nonce too low') ||
+    m.includes('replacement transaction underpriced') ||
+    m.includes('intrinsic gas too low') ||
+    m.includes('gas required exceeds') ||
+    m.includes('exceeds block gas limit')
+  )
+    return 'definitive';
+  // Everything else (rate limit, 5xx, network, ethers SERVER_ERROR) is
+  // worth re-trying against the next URL.
+  return 'transient';
+};
+
+const mapDefinitiveError = (msg: string): ProviderRpcError => {
+  const m = msg.toLowerCase();
+  if (m.includes('insufficient funds')) {
+    return createProviderRpcError(4000, 'Insufficient balance to complete this transaction.');
+  }
+  if (m.includes('nonce too low')) {
+    return createProviderRpcError(4000, 'Transaction nonce conflict. Please try again.');
+  }
+  if (m.includes('replacement transaction underpriced')) {
+    return createProviderRpcError(4000, 'Transaction fee too low. Try with a higher gas price.');
+  }
+  if (m.includes('gas required exceeds') || m.includes('exceeds block gas limit')) {
+    return createProviderRpcError(4000, 'Transaction requires more gas than available.');
+  }
+  return createProviderRpcError(4000, `Error broadcasting transaction: ${msg}`);
+};
+
 const broadcastTransaction = async (signedTx: string, expectedFrom?: string) => {
   const tag = TAG + ' | broadcastTransaction | ';
+
+  // ---- Pre-flight: decode + signer-recovery check (unchanged) ----
+  // ethers' `Transaction.from(...)` parses the serialized RLP and
+  // exposes `.from` as the ECDSA-recovered signer. If any of {chainId
+  // encoding, type-2 envelope, v/r/s} is malformed by the signing
+  // pipeline, the recovered address will be a deterministic-but-wrong
+  // address — *not* the user's. Fail closed before broadcast: an RPC
+  // that accepts the bytes against the wrong account is the worst
+  // outcome (funds move from a wallet the user doesn't control). See
+  // RETRO_uniswap_swap_dropped_tx.md and feedback_eip712_diagnosis.md.
+  let parsedHash: string | null = null;
+  let recoveredFrom: string | null = null;
+  let signerMismatch = false;
   try {
-    const provider = await getProvider();
-
-    console.log(tag, 'provider: ', provider);
-    console.log(`[HANDOFF] BEX → RPC (broadcast) signedTx=${signedTx}`);
-
-    // Decode-and-recover BEFORE broadcast. ethers' `Transaction.from(...)` parses
-    // the serialized RLP and exposes `.from` as the ECDSA-recovered signer. If
-    // any of {chainId encoding, type-2 envelope, v/r/s} is malformed by the
-    // signing pipeline, the recovered address will be a deterministic-but-wrong
-    // address — *not* the user's. Fail closed before broadcast: an RPC that
-    // accepts the bytes against the wrong account is the worst outcome (funds
-    // move from a wallet the user doesn't control). See
-    // RETRO_uniswap_swap_dropped_tx.md and feedback_eip712_diagnosis.md.
-    let recoveredFrom: string | null = null;
-    let signerMismatch = false;
-    try {
-      const parsed = Transaction.from(signedTx);
-      recoveredFrom = parsed.from ?? null;
-      const expectedNorm = expectedFrom ? expectedFrom.toLowerCase() : null;
-      const recoveredNorm = recoveredFrom ? recoveredFrom.toLowerCase() : null;
-      const match = expectedNorm && recoveredNorm ? expectedNorm === recoveredNorm : null;
-      console.log(
-        `[DECODE] signed tx parsed:\n` +
-          `  type=${parsed.type} chainId=${parsed.chainId} nonce=${parsed.nonce}\n` +
-          `  to=${parsed.to} value=${parsed.value?.toString()} gasLimit=${parsed.gasLimit?.toString()}\n` +
-          `  maxFeePerGas=${parsed.maxFeePerGas?.toString()} maxPriorityFeePerGas=${parsed.maxPriorityFeePerGas?.toString()} gasPrice=${parsed.gasPrice?.toString()}\n` +
-          `  data=${parsed.data?.slice(0, 80)}${(parsed.data?.length ?? 0) > 80 ? '…' : ''}\n` +
-          `  recoveredFrom=${recoveredFrom ?? '(no signature)'} expectedFrom=${expectedFrom ?? '(unknown)'} match=${match}\n` +
-          `  hash=${parsed.hash} signature=${JSON.stringify(parsed.signature?.toJSON())}`,
-      );
-      signerMismatch = match === false;
-    } catch (decodeErr) {
-      console.warn(`[DECODE] failed to parse signed tx — bytes are likely malformed:`, decodeErr);
-    }
-
-    if (signerMismatch) {
-      const msg = `Refusing to broadcast: recovered signer ${recoveredFrom} ≠ expected ${expectedFrom}. The signed bytes do not represent a tx from your account.`;
-      console.error(`[DECODE] ❌ MALFORMED-HEX ${msg}`);
-      throw createProviderRpcError(4000, msg);
-    }
-
-    const txResponse = await provider.broadcastTransaction(signedTx);
+    const parsed = Transaction.from(signedTx);
+    parsedHash = parsed.hash ?? null;
+    recoveredFrom = parsed.from ?? null;
+    const expectedNorm = expectedFrom ? expectedFrom.toLowerCase() : null;
+    const recoveredNorm = recoveredFrom ? recoveredFrom.toLowerCase() : null;
+    const match = expectedNorm && recoveredNorm ? expectedNorm === recoveredNorm : null;
     console.log(
-      `[HANDOFF] RPC → BEX (broadcast result) hash=${txResponse?.hash} from=${txResponse?.from} nonce=${txResponse?.nonce} to=${txResponse?.to}`,
+      `[DECODE] signed tx parsed:\n` +
+        `  type=${parsed.type} chainId=${parsed.chainId} nonce=${parsed.nonce}\n` +
+        `  to=${parsed.to} value=${parsed.value?.toString()} gasLimit=${parsed.gasLimit?.toString()}\n` +
+        `  maxFeePerGas=${parsed.maxFeePerGas?.toString()} maxPriorityFeePerGas=${parsed.maxPriorityFeePerGas?.toString()} gasPrice=${parsed.gasPrice?.toString()}\n` +
+        `  data=${parsed.data?.slice(0, 80)}${(parsed.data?.length ?? 0) > 80 ? '…' : ''}\n` +
+        `  recoveredFrom=${recoveredFrom ?? '(no signature)'} expectedFrom=${expectedFrom ?? '(unknown)'} match=${match}\n` +
+        `  hash=${parsed.hash} signature=${JSON.stringify(parsed.signature?.toJSON())}`,
     );
-    // Two-stage drop check: 8s catches "never landed in mempool" cases;
-    // 45s catches "landed briefly then evicted" — the user's real failure
-    // mode. Fire-and-forget; do not block the dApp response.
-    if (txResponse?.hash) {
-      scheduleDropCheck(txResponse.hash, 8_000);
-      scheduleDropCheck(txResponse.hash, 45_000);
-    }
-    return txResponse.hash;
-  } catch (e) {
-    console.error(tag, e);
-
-    // Already a ProviderRpcError (e.g. our signer-mismatch fail-closed) —
-    // pass through so the dApp sees the precise reason instead of a wrapped
-    // "Error broadcasting transaction: ...".
-    if (e && typeof (e as { code?: unknown }).code === 'number') throw e;
-
-    const errorMessage = e?.message || JSON.stringify(e);
-
-    if (errorMessage.includes('insufficient funds')) {
-      throw createProviderRpcError(4000, 'Insufficient balance to complete this transaction.');
-    } else if (errorMessage.includes('nonce too low')) {
-      throw createProviderRpcError(4000, 'Transaction nonce conflict. Please try again.');
-    } else if (errorMessage.includes('replacement transaction underpriced')) {
-      throw createProviderRpcError(4000, 'Transaction fee too low. Try with a higher gas price.');
-    } else if (errorMessage.includes('gas required exceeds')) {
-      throw createProviderRpcError(4000, 'Transaction requires more gas than available.');
-    } else if (errorMessage.includes('timeout')) {
-      throw createProviderRpcError(4000, 'Network timeout. Please try again.');
-    }
-
-    throw createProviderRpcError(4000, `Error broadcasting transaction: ${errorMessage}`);
+    signerMismatch = match === false;
+  } catch (decodeErr) {
+    console.warn(`[DECODE] failed to parse signed tx — bytes are likely malformed:`, decodeErr);
   }
+  if (signerMismatch) {
+    const msg = `Refusing to broadcast: recovered signer ${recoveredFrom} ≠ expected ${expectedFrom}. The signed bytes do not represent a tx from your account.`;
+    console.error(`[DECODE] ❌ MALFORMED-HEX ${msg}`);
+    throw createProviderRpcError(4000, msg);
+  }
+
+  // ---- Build candidate URL list ----
+  // Pioneer-discovered URLs always win priority. The hardcoded
+  // last-resort list is appended at the END (see lastResortRpcs.ts) so
+  // it can never preempt a working live node.
+  const currentProvider = await web3ProviderStorage.getWeb3Provider();
+  if (!currentProvider) {
+    throw createProviderRpcError(4900, 'Provider not configured for broadcast');
+  }
+  const networkId: string =
+    currentProvider.networkId ||
+    (parseChainId(currentProvider.chainId) != null ? `eip155:${parseChainId(currentProvider.chainId)}` : '');
+
+  const pioneerUrls: string[] =
+    currentProvider.providers && currentProvider.providers.length > 0
+      ? currentProvider.providers
+      : currentProvider.providerUrl
+        ? [currentProvider.providerUrl]
+        : [];
+  const lastResort = networkId ? getLastResortRpcs(networkId) : [];
+
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+  for (const u of [...pioneerUrls, ...lastResort]) {
+    const t = (u || '').trim();
+    if (t && !seen.has(t)) {
+      seen.add(t);
+      candidates.push(t);
+    }
+  }
+  if (candidates.length === 0) {
+    throw createProviderRpcError(4900, 'No RPC URLs available for broadcast');
+  }
+
+  // Skip URLs in the recent-failure cooldown unless every candidate is
+  // cooling — in that case clear and try the whole set. Same convention
+  // as getProvider.
+  const now = Date.now();
+  for (const [url, failedAt] of failedRpcs) {
+    if (now - failedAt >= RPC_RETRY_DELAY) failedRpcs.delete(url);
+  }
+  let availableRpcs = candidates.filter(url => {
+    const failedAt = failedRpcs.get(url);
+    return !(failedAt && now - failedAt < RPC_RETRY_DELAY);
+  });
+  if (availableRpcs.length === 0) {
+    console.warn(tag, 'All candidate RPCs in cooldown — clearing and retrying');
+    failedRpcs.clear();
+    availableRpcs = candidates.slice();
+  }
+
+  // ---- Failover loop ----
+  const errors: { url: string; error: string }[] = [];
+  for (const url of availableRpcs) {
+    try {
+      console.log(`[HANDOFF] BEX → RPC (broadcast attempt) url=${url} signedTx=${signedTx}`);
+      const provider = makeStaticProvider(url, networkId || currentProvider.chainId);
+      const txResponse = await provider.broadcastTransaction(signedTx);
+      console.log(
+        `[HANDOFF] RPC → BEX (broadcast success) hash=${txResponse?.hash} url=${url} from=${txResponse?.from} nonce=${txResponse?.nonce}`,
+      );
+      // Two-stage drop check: 8s catches "never landed in mempool" cases;
+      // 45s catches "landed briefly then evicted". Fire-and-forget; do
+      // not block the dApp response.
+      if (txResponse?.hash) {
+        scheduleDropCheck(txResponse.hash, 8_000);
+        scheduleDropCheck(txResponse.hash, 45_000);
+      }
+      return txResponse.hash;
+    } catch (e: any) {
+      const errMsg = String(e?.message || e);
+      const kind = classifyBroadcastError(errMsg);
+
+      if (kind === 'definitive') {
+        // Tx-level rejection. Other RPCs will say the same thing —
+        // surface immediately rather than walking the whole list.
+        console.error(tag, `Broadcast definitive error on ${url} — not failing over:`, errMsg);
+        throw mapDefinitiveError(errMsg);
+      }
+
+      if (kind === 'already-known') {
+        // Tx is in mempool somewhere. Use the locally-recovered hash and
+        // treat as success.
+        if (parsedHash) {
+          console.log(tag, `Broadcast on ${url} returned already-known; using parsed hash:`, parsedHash);
+          scheduleDropCheck(parsedHash, 8_000);
+          scheduleDropCheck(parsedHash, 45_000);
+          return parsedHash;
+        }
+        // No parsed hash — fall through to next URL.
+      }
+
+      console.warn(tag, `RPC ${url} broadcast failed (${kind}), trying next:`, errMsg);
+      errors.push({ url, error: errMsg });
+      failedRpcs.set(url, now);
+    }
+  }
+
+  // All candidates failed — surface the last error.
+  console.error(tag, 'All RPC endpoints failed broadcast:', errors);
+  const lastErr = errors[errors.length - 1]?.error || 'unknown error';
+  if (lastErr.toLowerCase().includes('timeout')) {
+    throw createProviderRpcError(4000, 'Network timeout. Please try again.');
+  }
+  throw createProviderRpcError(
+    4900,
+    `All ${availableRpcs.length} RPC endpoints failed broadcast. Last error: ${lastErr}`,
+  );
 };
 
 /**

--- a/chrome-extension/src/background/chains/ethereumHandler.ts
+++ b/chrome-extension/src/background/chains/ethereumHandler.ts
@@ -346,10 +346,11 @@ const handleEthSendRawTransaction = async params => {
   // (already signed externally) BEFORE we relay it to the RPC. Paste
   // params[0] into an EVM tx decoder to inspect its contents.
   console.log(`[HANDOFF] dApp → BEX (eth_sendRawTransaction) rawTx=${params[0]}`);
-  const provider = await getProvider();
-  const txResponse = await provider.broadcastTransaction(params[0]);
-  console.log(`[HANDOFF] RPC → BEX (eth_sendRawTransaction result) hash=${txResponse?.hash}`);
-  return txResponse.hash;
+  // Route through the failover-aware helper so raw signed tx submissions
+  // get the same RPC iteration / last-resort fallback / already-known
+  // handling as eth_sendTransaction. expectedFrom is unknown (the dApp
+  // already signed externally), so the signer-mismatch check is skipped.
+  return await broadcastTransaction(params[0]);
 };
 
 // Helper function to switch to a provider and update contexts
@@ -1559,7 +1560,11 @@ const broadcastTransaction = async (signedTx: string, expectedFrom?: string) => 
   for (const url of availableRpcs) {
     try {
       console.log(`[HANDOFF] BEX → RPC (broadcast attempt) url=${url} signedTx=${signedTx}`);
-      const provider = makeStaticProvider(url, networkId || currentProvider.chainId);
+      // 4s per HTTP attempt + no internal throttle retries: ensures a
+      // 429/dead URL doesn't stall the failover loop. ethers' default
+      // FetchRequest retries 429/5xx with exponential backoff for ~30s,
+      // which is exactly the lag this loop is meant to eliminate.
+      const provider = makeStaticProvider(url, networkId || currentProvider.chainId, { timeoutMs: 4000 });
       const txResponse = await provider.broadcastTransaction(signedTx);
       console.log(
         `[HANDOFF] RPC → BEX (broadcast success) hash=${txResponse?.hash} url=${url} from=${txResponse?.from} nonce=${txResponse?.nonce}`,
@@ -1688,6 +1693,11 @@ const sendTransaction = async (params: any, KEEPKEY_WALLET: any, ADDRESS: string
     return txHash;
   } catch (e) {
     console.error(e);
+    // Pass ProviderRpcErrors through unchanged so the dApp sees the
+    // precise reason (insufficient funds, nonce conflict, all RPCs
+    // failed, etc.) instead of a generic "Error sending transaction"
+    // that swallows our broadcastTransaction classifier output.
+    if (e && typeof (e as { code?: unknown }).code === 'number') throw e;
     throw createProviderRpcError(4000, 'Error sending transaction', e);
   }
 };

--- a/chrome-extension/src/background/chains/lastResortRpcs.ts
+++ b/chrome-extension/src/background/chains/lastResortRpcs.ts
@@ -1,0 +1,47 @@
+/**
+ * Last-resort EVM RPC URLs for the broadcast failover loop.
+ *
+ * # Why this exists
+ *
+ * Pioneer is the source of truth for chain RPCs (see `registry.ts`).
+ * BUT during a broadcast we sometimes need to try multiple URLs because
+ * a single endpoint rate-limited (the Tenderly-on-Optimism case from
+ * 2026-04-30). When Pioneer's full list is exhausted — or when Pioneer
+ * itself is unreachable — we still want the user's transaction to land.
+ *
+ * # The rule
+ *
+ * **Pioneer URLs always run FIRST. This list runs LAST.**
+ *
+ * The historical objection to a hardcoded RPC table (see
+ * `feedback_no_hardcoded_rpcs.md`) was that it could *block* live
+ * Pioneer nodes when entries went stale, forcing emergency releases to
+ * fix individual URL rot. Appending the table to the end of the loop
+ * removes that risk: a stale entry can only fail; it can never preempt
+ * a working Pioneer-discovered URL.
+ *
+ * # How to maintain
+ *
+ * Keep this list small (2 URLs per chain is enough). Pick canonical
+ * public endpoints that have been historically reliable: chain-team
+ * official RPCs, drpc.org, publicnode.com. Don't use anything that
+ * needs an API key.
+ *
+ * If a chain isn't here, broadcast failover relies entirely on the
+ * Pioneer list — which is fine for the long tail.
+ */
+
+const RPCS: Record<string, string[]> = {
+  'eip155:1': ['https://ethereum-rpc.publicnode.com', 'https://eth.drpc.org'],
+  'eip155:10': ['https://mainnet.optimism.io', 'https://optimism-rpc.publicnode.com'],
+  'eip155:56': ['https://bsc-rpc.publicnode.com', 'https://bsc-dataseed.bnbchain.org'],
+  'eip155:137': ['https://polygon-rpc.com', 'https://polygon-bor-rpc.publicnode.com'],
+  'eip155:324': ['https://mainnet.era.zksync.io'],
+  'eip155:8453': ['https://mainnet.base.org', 'https://base-rpc.publicnode.com'],
+  'eip155:42161': ['https://arb1.arbitrum.io/rpc', 'https://arbitrum-one-rpc.publicnode.com'],
+  'eip155:43114': ['https://api.avax.network/ext/bc/C/rpc', 'https://avalanche-c-chain-rpc.publicnode.com'],
+};
+
+export function getLastResortRpcs(networkId: string): string[] {
+  return RPCS[networkId] ? [...RPCS[networkId]] : [];
+}

--- a/chrome-extension/src/background/chains/registry.ts
+++ b/chrome-extension/src/background/chains/registry.ts
@@ -26,12 +26,44 @@
  * chrome.storage would just create a new staleness vector.
  */
 
+import { JsonRpcProvider } from 'ethers';
+
 const PIONEER_API = 'https://api.keepkey.info';
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 const FAILURE_TTL_MS = 60 * 1000; // negative-cache misses for a minute
 const FETCH_TIMEOUT_MS = 8000;
 
 const TAG = ' | chains/registry | ';
+
+/**
+ * Construct a JsonRpcProvider with a *pinned* network. Without this,
+ * ethers v6 calls eth_chainId on the first RPC call to detect the
+ * network and retries every 1s indefinitely if the URL is slow / dead /
+ * rate-limited — generating background spam from any timed-out call
+ * site (`Promise.race(getBalance, timeout)` only rejects the awaiting
+ * promise; the abandoned provider keeps retrying).
+ *
+ * Pin the network up front so a bad URL fails fast on the actual call
+ * instead of looping on detection forever.
+ */
+export function makeStaticProvider(url: string, networkOrChainId: string | number): JsonRpcProvider {
+  let chainId: number | null = null;
+  if (typeof networkOrChainId === 'number') {
+    chainId = networkOrChainId;
+  } else if (typeof networkOrChainId === 'string') {
+    const s = networkOrChainId.trim();
+    const m = /^eip155:(\d+)$/.exec(s);
+    if (m) {
+      chainId = parseInt(m[1], 10);
+    } else {
+      const n = /^0x/i.test(s) ? parseInt(s, 16) : parseInt(s, 10);
+      if (Number.isFinite(n)) chainId = n;
+    }
+  }
+  return chainId != null
+    ? new JsonRpcProvider(url.trim(), chainId, { staticNetwork: true })
+    : new JsonRpcProvider(url.trim());
+}
 
 export interface ChainInfo {
   chainId: string; // hex, e.g. '0x38'

--- a/chrome-extension/src/background/chains/registry.ts
+++ b/chrome-extension/src/background/chains/registry.ts
@@ -26,7 +26,7 @@
  * chrome.storage would just create a new staleness vector.
  */
 
-import { JsonRpcProvider } from 'ethers';
+import { FetchRequest, JsonRpcProvider } from 'ethers';
 
 const PIONEER_API = 'https://api.keepkey.info';
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -45,24 +45,52 @@ const TAG = ' | chains/registry | ';
  *
  * Pin the network up front so a bad URL fails fast on the actual call
  * instead of looping on detection forever.
+ *
+ * `timeoutMs` (optional): when set, builds a `FetchRequest` with a
+ * per-HTTP-attempt timeout AND disables ethers' throttle-retry
+ * behavior. Without it, ethers will silently retry 429/5xx responses
+ * with exponential backoff for ~30s before surfacing the error — which
+ * stalls the broadcast failover loop. Pass a short value (e.g. 4000)
+ * for paths that need snappy fall-through.
  */
-export function makeStaticProvider(url: string, networkOrChainId: string | number): JsonRpcProvider {
-  let chainId: number | null = null;
+function parseChainIdFromArg(networkOrChainId: string | number): number | null {
   if (typeof networkOrChainId === 'number') {
-    chainId = networkOrChainId;
-  } else if (typeof networkOrChainId === 'string') {
-    const s = networkOrChainId.trim();
-    const m = /^eip155:(\d+)$/.exec(s);
-    if (m) {
-      chainId = parseInt(m[1], 10);
-    } else {
-      const n = /^0x/i.test(s) ? parseInt(s, 16) : parseInt(s, 10);
-      if (Number.isFinite(n)) chainId = n;
-    }
+    return Number.isFinite(networkOrChainId) ? networkOrChainId : null;
   }
+  const s = networkOrChainId.trim();
+  const m = /^eip155:(\d+)$/.exec(s);
+  if (m) return parseInt(m[1], 10);
+  const n = /^0x/i.test(s) ? parseInt(s, 16) : parseInt(s, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function makeStaticProvider(
+  url: string,
+  networkOrChainId: string | number,
+  options?: { timeoutMs?: number },
+): JsonRpcProvider {
+  const chainId = parseChainIdFromArg(networkOrChainId);
+  const cleanUrl = url.trim();
+  const timeoutMs = options?.timeoutMs;
+
+  // Path A: bounded HTTP timeout + no throttle retries. Use FetchRequest
+  // so we hit ethers' transport layer, not just the awaiting promise.
+  if (timeoutMs && timeoutMs > 0) {
+    const fetchReq = new FetchRequest(cleanUrl);
+    fetchReq.timeout = timeoutMs;
+    // Disable the implicit throttle-retry loop ethers does on 429/5xx.
+    // We're handling failover ourselves at a higher level — internal
+    // retries here just delay surfacing the error.
+    fetchReq.setThrottleParams({ maxAttempts: 1 });
+    return chainId != null
+      ? new JsonRpcProvider(fetchReq, chainId, { staticNetwork: true })
+      : new JsonRpcProvider(fetchReq);
+  }
+
+  // Path B: default behavior preserved for non-broadcast call sites.
   return chainId != null
-    ? new JsonRpcProvider(url.trim(), chainId, { staticNetwork: true })
-    : new JsonRpcProvider(url.trim());
+    ? new JsonRpcProvider(cleanUrl, chainId, { staticNetwork: true })
+    : new JsonRpcProvider(cleanUrl);
 }
 
 export interface ChainInfo {

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -25,7 +25,7 @@ import {
   ethAccountsStorage,
   customEvmNetworksStorage,
 } from '@extension/storage';
-import { getChainInfo } from './chains/registry';
+import { getChainInfo, makeStaticProvider } from './chains/registry';
 import { formatUserError } from './utils';
 import { filterSpamTokens } from './spamFilter';
 
@@ -482,7 +482,7 @@ async function fetchBalancesFromPioneer(forceRefresh = false): Promise<any[]> {
             if (!chainData?.providerUrl) continue;
 
             try {
-              const rpcProvider = new JsonRpcProvider(chainData.providerUrl);
+              const rpcProvider = makeStaticProvider(chainData.providerUrl, networkId);
               const rawBal = await Promise.race([
                 rpcProvider.getBalance(evmAddress),
                 new Promise<bigint>((_, reject) => setTimeout(() => reject(new Error('timeout')), 5000)),
@@ -888,7 +888,10 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
           try {
             const providerInfo = await web3ProviderStorage.getWeb3Provider();
             if (!providerInfo) throw Error('Failed to get provider info');
-            const evmProvider = new JsonRpcProvider(providerInfo.providerUrl);
+            const evmProvider = makeStaticProvider(
+              providerInfo.providerUrl,
+              providerInfo.networkId || providerInfo.chainId,
+            );
             const feeData = await evmProvider.getFeeData();
             sendResponse(feeData);
           } catch (error: any) {
@@ -1346,7 +1349,7 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
             }
 
             if (rpcUrl && ADDRESS) {
-              const evmProvider = new JsonRpcProvider(rpcUrl);
+              const evmProvider = makeStaticProvider(rpcUrl, networkId);
               const balance = await evmProvider.getBalance(ADDRESS);
               sendResponse('0x' + balance.toString(16));
             } else {
@@ -1488,7 +1491,7 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
               break;
             }
 
-            const rpcProvider = new JsonRpcProvider(rpcUrl);
+            const rpcProvider = makeStaticProvider(rpcUrl, evmNetworkId);
             const rawBal = await Promise.race([
               rpcProvider.getBalance(evmAddress),
               new Promise<bigint>((_, reject) => setTimeout(() => reject(new Error('timeout')), 8000)),
@@ -1695,7 +1698,7 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
               break;
             }
 
-            const rpcProvider = new JsonRpcProvider(rpcUrl);
+            const rpcProvider = makeStaticProvider(rpcUrl, networkId);
 
             // ERC-20 ABI for name, symbol, and decimals
             const ERC20_ABI = [


### PR DESCRIPTION
## Summary

Optimism broadcast hit rate-limit (Tenderly public, HTTP 429 / `-32005`). `getProvider()` did failover for its pre-flight `getBlockNumber` but every subsequent call hit the same single URL — signing succeeded, broadcast failed.

This PR makes broadcast iterate the full RPC list and adds a hardcoded last-resort table that runs **after** Pioneer's list (so it can never preempt a live node).

## What changed

**Broadcast failover** (`broadcastTransaction` in `ethereumHandler.ts`)
- Iterates all candidate RPCs in order.
- New `classifyBroadcastError` distinguishes:
  - `definitive` — `insufficient funds`, `nonce too low`, `replacement transaction underpriced`, `gas required exceeds`, `intrinsic gas too low`. Same outcome on any RPC; throw immediately.
  - `already-known` — tx is in mempool somewhere; treat as success and return the locally-recovered hash from the signed bytes.
  - `transient` — rate limit, 5xx, network, ethers `SERVER_ERROR`. Mark URL failed for 60s, try next.
- The pre-flight signer-recovery / signer-mismatch fail-closed check is preserved.
- The 8s + 45s drop checks still fire on success.

**Last-resort RPC list** (`chains/lastResortRpcs.ts`, new)
- Hardcoded canonical public RPCs for the 8 main chains (ETH/Optimism/BSC/Polygon/zkSync/Base/Arbitrum/Avalanche), 1–2 entries each.
- **Always appended after Pioneer's list** in the failover sequence — Pioneer URLs always win priority. A stale entry in this table can fail; it can never preempt a working Pioneer-discovered URL. Addresses the historical concern from `feedback_no_hardcoded_rpcs.md`.

**Pinned-network `JsonRpcProvider`** (`makeStaticProvider` in `chains/registry.ts`)
- ethers v6 default behavior calls `eth_chainId` to auto-detect the network on the first RPC call, and retries every 1s indefinitely if the URL is slow / dead / rate-limited. `Promise.race(getBalance, timeout)` rejects the awaiting promise but leaves the abandoned provider retrying — which is the source of the `JsonRpcProvider failed to detect network and cannot start up; retry in 1s` spam (50+ lines per balance refresh).
- New helper passes `staticNetwork: true` and the chainId at construction time so ethers skips detection. Bad URLs fail fast on the actual call.
- Applied at all 6 construction sites: `index.ts:485` (fetchBalances), `:891` (GET_GAS_ESTIMATE), `:1352` (GET_ASSET_BALANCE), `:1494` (GET_EVM_BALANCE), `:1701` (VALIDATE_ERC20_TOKEN), `ethereumHandler.ts:150` (getProvider).

## Out of scope

`signTransaction` pre-flight calls (`getTransactionCount`, `estimateGas`, `getFeeData`) still hit a single URL via `getProvider()`. If those rate-limit you'll see different failure modes — fee data unavailable, nonce 0, etc. Worth following up but a separate PR.

## Files

- `chrome-extension/src/background/chains/lastResortRpcs.ts` (new)
- `chrome-extension/src/background/chains/registry.ts` — `makeStaticProvider` export
- `chrome-extension/src/background/chains/ethereumHandler.ts` — broadcast loop rewrite, getProvider uses pinned helper
- `chrome-extension/src/background/index.ts` — 5 JsonRpcProvider sites use pinned helper

## Test plan

- [ ] Optimism tx broadcast: trigger the rate-limit case (e.g. burst many txs or hit Tenderly's rough threshold). First URL 429s; failover catches it; tx lands on a subsequent URL. Console shows `[HANDOFF] BEX → RPC (broadcast attempt) url=...` for each attempt.
- [ ] BSC, Ethereum, Base broadcasts each work via Pioneer's list (no last-resort needed).
- [ ] Send a bad-nonce tx (e.g. with stale `nonce: 0`) — should fail definitively after the first URL, not walk the whole list.
- [ ] `fetchBalances` with multiple chains in storage: console no longer shows the 50× `JsonRpcProvider failed to detect network` spam after a chain switch. Bad URLs fail within 5s instead of looping.
- [ ] After a URL rate-limits, repeat the same broadcast within 60s — that URL is skipped (failedRpcs cooldown).
- [ ] After 60s without retries, the same URL is retried.
- [ ] `already known` path: difficult to trigger naturally; skip if not reproducible.
- [ ] Existing one-step add+switch (BSC) from #57 still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)