### PR TITLE
fix(masking): default MetaMask masking ON; readable contrast on Settings text

### DIFF
--- a/packages/storage/lib/customStorage.ts
+++ b/packages/storage/lib/customStorage.ts
@@ -363,7 +363,12 @@ const createMaskingSettingsStorage = (): MaskingSettingsStorage => {
   const storage = createStorage<MaskingSettings>(
     'masking-settings',
     {
-      enableMetaMaskMasking: false,
+      // Default ON — modern dApps (CowSwap, swap aggregators, several
+      // older sites) expect a window.ethereum with isMetaMask:true and
+      // bail out of their connect flow without it. Modern dApps that
+      // discover wallets via EIP-6963 still see KeepKey as itself.
+      // Existing installs keep whatever they previously set.
+      enableMetaMaskMasking: true,
       enableXfiMasking: false,
       enableKeplrMasking: false,
     },

--- a/pages/side-panel/src/components/Settings.tsx
+++ b/pages/side-panel/src/components/Settings.tsx
@@ -198,7 +198,7 @@ const Settings = () => {
           </HStack>
           <Switch size="md" isChecked={maskingSettings.enableMetaMaskMasking} onChange={toggleMetaMaskMasking} />
         </HStack>
-        <Text fontSize="xs" color="gray.500" mt={-2} mb={2}>
+        <Text fontSize="xs" color="whiteAlpha.700" mt={-2} mb={2}>
           When on, KeepKey claims to be MetaMask on legacy dApps (Stripe, older sites) by mounting
           <code> window.ethereum </code>
           with <code>isMetaMask: true</code>. Modern dApps still see KeepKey via EIP-6963. Refresh any open dApp after
@@ -269,7 +269,7 @@ const Settings = () => {
           )}
         </Box>
 
-        <Text fontSize="sm" color="gray.500">
+        <Text fontSize="sm" color="whiteAlpha.700">
           This setting may conflict with these apps if also enabled.
         </Text>
 


### PR DESCRIPTION
## Two issues on the Side Panel → Settings → "Enable Masking" surface

### 1. MetaMask masking now defaults to **ON**

CowSwap and several swap aggregators bail out of their connect flow without a `window.ethereum` carrying `isMetaMask: true`. Modern dApps that discover wallets via EIP-6963 still see KeepKey as itself, so flipping the default is purely additive — sites that work with the masking off still work, and sites that need it stop being broken on first install.

**Existing installs keep whatever they previously set** (chrome.storage persists the boolean once it's been read). Only fresh installs / cleared storage pick up the new default. If we want to forcibly upgrade existing users (e.g. one-time migration that flips false→true once), that's a separate change — call it out and I'll add it.

### 2. The body-text labels were unreadable

`color="gray.500"` is fine on a light background but the side panel's dark theme makes it ~black-on-black. The two affected lines are the MetaMask description and the conflict-warning under the Coming Soon rows — the latter being exactly the part the user most needs to see.

Switched both to `color="whiteAlpha.700"`, the codebase convention for secondary copy on dark surfaces (used in `Connect.tsx`, `Balances.tsx`, `Tokens.tsx`, `CustomTokenDialog.tsx`).

## Files

- `packages/storage/lib/customStorage.ts` — `enableMetaMaskMasking: false` → `true` in the masking-settings storage default.
- `pages/side-panel/src/components/Settings.tsx` — two `gray.500` → `whiteAlpha.700` color swaps.

## Test plan

- [ ] Fresh install (or: clear extension storage) → Settings shows MetaMask Masking toggle ON.
- [ ] Visit cowswap.exchange / 1inch / similar — connect flow lights up KeepKey.
- [ ] Both description blurbs are readable on the dark Settings background.
- [ ] Toggling off → on → off persists across reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)