### PR TITLE
fix: drop chrome.alarms permission (0.0.30 release)

### DIFF
--- a/chrome-extension/manifest.js
+++ b/chrome-extension/manifest.js
@@ -37,7 +37,7 @@ const manifest = deepmerge(
     version: packageJson.version,
     description: '__MSG_extensionDescription__',
     host_permissions: ['<all_urls>'],
-    permissions: ['storage', 'tabs', 'commands', 'alarms'],
+    permissions: ['storage', 'tabs', 'commands'],
     options_page: 'options/index.html',
     background: {
       service_worker: 'background.iife.js',

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-extension",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - core settings",
   "type": "module",
   "scripts": {

--- a/chrome-extension/src/background/chains/ethereumHandler.ts
+++ b/chrome-extension/src/background/chains/ethereumHandler.ts
@@ -1376,15 +1376,16 @@ const signTypedData = async (params: any, KEEPKEY_WALLET: any, ADDRESS: string, 
  * a clear warning and emits a runtime message so the side-panel (or any
  * listener) can surface it. See RETRO_uniswap_swap_dropped_tx.md.
  *
- * Two delivery mechanisms:
- *   - Short delays (< 30s): setTimeout. Best-effort; only fires if the
- *     MV3 service worker is still alive. The 8s check usually hits while
- *     the SW is still warm from the broadcast.
- *   - Long delays (>= 30s): chrome.alarms. Survives SW suspension —
- *     the alarm wakes the SW, registering the listener at module load.
- *     Production minimum delay is 30s; we use 45s for the eviction probe.
+ * Best-effort via setTimeout. Both 8s and 45s checks fire only if the
+ * MV3 service worker is still alive at delay time. The 8s check almost
+ * always hits because the broadcast just happened. The 45s check fires
+ * during active dApp interaction (block polling / eth_chainId pings
+ * keep the SW warm) but may miss if the SW idles immediately after
+ * broadcast — acceptable trade for not requiring the chrome.alarms
+ * permission, which would gate Chrome Web Store updates on user
+ * re-consent. The drop warning is diagnostic UX; the tx outcome is
+ * unchanged when the warning is missed.
  */
-const DROP_CHECK_ALARM_PREFIX = 'eth-drop-check-';
 
 // Map hash → URL that successfully accepted the broadcast. Drop-check
 // then queries that exact RPC instead of running getProvider() again,
@@ -1431,37 +1432,8 @@ const performDropCheck = async (hash: string, scheduledDelayMs: number) => {
 
 const scheduleDropCheck = (hash: string, delayMs: number, successUrl?: string) => {
   if (successUrl) dropCheckUrlByHash.set(hash, successUrl);
-  if (delayMs < 30_000) {
-    setTimeout(() => performDropCheck(hash, delayMs), delayMs);
-    return;
-  }
-  // Encode delay in alarm name so the listener can recover it without
-  // a separate storage round-trip. Alarms are unique by name; suffixing
-  // with delayMs lets us schedule multiple checks for the same hash.
-  const alarmName = `${DROP_CHECK_ALARM_PREFIX}${hash}-${delayMs}`;
-  try {
-    chrome.alarms.create(alarmName, { when: Date.now() + delayMs });
-  } catch (e) {
-    console.warn('[DROP-CHECK] alarm scheduling failed, falling back to setTimeout:', e);
-    setTimeout(() => performDropCheck(hash, delayMs), delayMs);
-  }
+  setTimeout(() => performDropCheck(hash, delayMs), delayMs);
 };
-
-// Registered at module load — re-runs on every service-worker startup,
-// which is exactly when the alarm fires and wakes the SW. (URL hint
-// is not recovered across SW restart; drop-check falls back to
-// getProvider in that case.)
-if (typeof chrome !== 'undefined' && chrome.alarms?.onAlarm) {
-  chrome.alarms.onAlarm.addListener(alarm => {
-    if (!alarm.name.startsWith(DROP_CHECK_ALARM_PREFIX)) return;
-    const rest = alarm.name.slice(DROP_CHECK_ALARM_PREFIX.length);
-    const lastDash = rest.lastIndexOf('-');
-    if (lastDash <= 0) return;
-    const hash = rest.slice(0, lastDash);
-    const delayMs = Number(rest.slice(lastDash + 1));
-    void performDropCheck(hash, Number.isFinite(delayMs) ? delayMs : 0);
-  });
-}
 
 /**
  * Classify a broadcast error so the failover loop knows whether to try

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keepkey-client",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension for KeepKey",
   "license": "GNU General Public License v3.0",
   "repository": {
@@ -36,7 +36,7 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
-    "@types/chrome": "^0.0.290",
+    "@types/chrome": "^0.0.300",
     "@types/node": "^20.16.11",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/dev-utils",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - dev utils",
   "private": true,
   "sideEffects": false,

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/hmr",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - hot module reload/refresh",
   "private": true,
   "sideEffects": true,

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/i18n",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - internationalization",
   "private": true,
   "sideEffects": false,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/shared",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - shared code",
   "private": true,
   "sideEffects": false,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/storage",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - storage",
   "private": true,
   "sideEffects": false,

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/tailwindcss-config",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - tailwindcss configuration",
   "main": "tailwind.config.ts",
   "private": true

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/tsconfig",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - tsconfig",
   "private": true
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/ui",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - ui components",
   "private": true,
   "sideEffects": false,

--- a/packages/vite-config/package.json
+++ b/packages/vite-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/vite-config",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - vite base configuration",
   "main": "index.mjs",
   "type": "module",

--- a/packages/zipper/package.json
+++ b/packages/zipper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/zipper",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - zipper",
   "private": true,
   "sideEffects": false,

--- a/pages/content-runtime/package.json
+++ b/pages/content-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/content-runtime-script",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - content runtime script",
   "private": true,
   "sideEffects": true,

--- a/pages/content-ui/package.json
+++ b/pages/content-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/content-ui",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - content ui",
   "type": "module",
   "private": true,

--- a/pages/content/package.json
+++ b/pages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/content-script",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - content script",
   "private": true,
   "sideEffects": true,

--- a/pages/devtools-panel/package.json
+++ b/pages/devtools-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/devtools-panel",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - devtools panel",
   "private": true,
   "sideEffects": true,

--- a/pages/devtools/package.json
+++ b/pages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/devtools",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - devtools",
   "private": true,
   "sideEffects": true,

--- a/pages/options/package.json
+++ b/pages/options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/options",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - options",
   "private": true,
   "sideEffects": true,

--- a/pages/side-panel/package.json
+++ b/pages/side-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/sidepanel",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "chrome extension - side panel",
   "private": true,
   "sideEffects": true,

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extension/e2e",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "E2e tests configuration boilerplate",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Why

Chrome Web Store update gates on permission additions — \`alarms\` was added in #55 to keep the 45s post-broadcast drop-check firing across MV3 service-worker idle eviction. **The drop-check is diagnostic UX, not load-bearing for tx safety:**

- 8s check still uses \`setTimeout\` (< 30s — always fires while SW is warm from broadcast)
- 45s check fires during active dApp interaction (block polling / eth_chainId pings keep SW alive)
- When the SW idles immediately after broadcast, we just miss the 45s warning. The tx outcome is unchanged.

Trading a rare diagnostic warning for not gating Chrome Web Store rollout on user re-consent.

## What's removed

- \`alarms\` permission from \`chrome-extension/manifest.js\`
- \`chrome.alarms.create\` call in \`scheduleDropCheck\`
- \`chrome.alarms.onAlarm\` listener registered at module load
- \`DROP_CHECK_ALARM_PREFIX\` constant + name-encoded delay parsing

\`scheduleDropCheck\` becomes a one-liner: \`setTimeout(performDropCheck, delayMs)\`.

## Version

Bumps to **0.0.30** (since 0.0.29 merge already landed on master). This is the version that ships to the Web Store.

## Files

- \`chrome-extension/manifest.js\`
- \`chrome-extension/src/background/chains/ethereumHandler.ts\`
- 20 × \`package.json\` version bumps via \`make bump VERSION=0.0.30\`

## Test plan

- [x] Build clean
- [x] \`dist/manifest.json\` permissions field no longer contains \`alarms\`
- [ ] Trigger a tx broadcast; verify \`[DROP-CHECK]\` line still logs at 8s
- [ ] During active dApp use (Uniswap polling), verify 45s check still fires (SW kept warm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)