### PR TITLE
feat(mcp): agent bridge phase 1 — BEX WebSocket client + tier-1 introspection tools

### DIFF
--- a/EPIC_mcp_agent_bridge.md
+++ b/EPIC_mcp_agent_bridge.md
@@ -1,0 +1,247 @@
+# EPIC → MCP Agent Bridge: let agents drive the BEX and the wallets it connects
+
+**From:** planning session (swapspro balance debugging, 2026-07-15)
+**Owners:** keepkey-client (BEX) + keepkey-vault (v11) — this epic spans both repos.
+**Repos:**
+- BEX: `/Users/highlander/WebstormProjects/keepkey-stack/projects/keepkey-client` (this repo)
+- Vault: `/Users/highlander/WebstormProjects/keepkey-stack/projects/keepkey-vault-v11/projects/keepkey-vault`
+
+> Absolute paths throughout (multi-repo stack). Vault REST base is
+> `http://localhost:1646` (`src/bun/rest-api.ts`); the BEX already pairs against
+> it (`HANDOFF_vault_connectivity_api.md`).
+
+---
+
+## Why (the motivating failure)
+
+An agent spent a session testing swapspro against the BEX **blind**. Three bugs
+that took hours to find would each have been a one-tool-call diagnosis:
+
+1. **Add Network spam** — connect fired N concurrent `wallet_switchEthereumChain`
+   requests; all but the first got `-32002`, and a catch-all fallback turned each
+   into a `wallet_addEthereumChain` prompt. Agent could not see the request
+   queue, the error codes, or the prompts. (`bex_pending_requests` + `bex_logs`
+   would have shown it instantly.)
+2. **Pubkey array bug** — Pioneer `/portfolio` 400'd because the BEX provider
+   returns an **array** for UTXO/Cosmos addresses where SwapKit expects a string
+   (`pubkeys.$9.pubkey: ["thor1g9el..."]`). Agent had no way to dump what the
+   BEX actually hands a dApp per chain. (`bex_accounts` would have shown the
+   shape mismatch before any UI existed.)
+3. **No end-to-end verification** — agent shipped a preview it could not click
+   through; the human found the breakage. (`bex_provider_request` +
+   approval-control closes the loop: agent tests connect→balances→swap alone.)
+
+Goal: an MCP server agents connect to that can **introspect and drive the BEX
+itself, and the wallets/dApp connections it manages** — so agent test loops are
+observable, scriptable, and don't need a human clicking the side panel.
+
+---
+
+## Architecture decision
+
+**The vault hosts the MCP endpoint; the BEX is a bridge client.**
+
+Chrome MV3 extensions cannot listen on a port, so the MCP server must live in a
+process that can. We already run one: the vault's Bun REST server on `:1646`,
+which the BEX already pairs with and holds credentials for. Reuse it.
+
+```
+Agent (Claude Code / any MCP client)
+   │  Streamable HTTP  POST http://localhost:1646/mcp
+   ▼
+Vault (Bun, src/bun/) ── MCP session state, tool registry, auth
+   │  WebSocket  ws://localhost:1646/bex-bridge   (BEX connects OUTBOUND,
+   ▼              Authorization: Bearer <existing pairing key>)
+BEX background service worker ── executes tool calls:
+   ├─ reads its own state (accounts, queue, logs, connected sites)
+   ├─ settles approvals (same runtime message the side panel sends)
+   └─ drives providers (window.keepkey.* handlers in background/chains/*)
+```
+
+- **Transport agent→vault:** MCP Streamable HTTP at `POST /mcp` (new handler in
+  `src/bun/rest-api.ts` territory; own module `src/bun/mcp.ts`).
+- **Transport vault→BEX:** one persistent outbound WebSocket from the BEX
+  background SW. Precedent already in-repo: `chrome-extension/src/background/
+  swapEventStream.ts` maintains a vault event stream; the bridge is the same
+  pattern with a request/response envelope (`{id, tool, args}` →
+  `{id, result | error}`). MV3 note: a WS keeps the SW alive while open, but the
+  bridge must survive SW restarts — reconnect on SW wake (same lifecycle hooks
+  the pairing init uses, see `background/index.ts`).
+- **Auth:** the BEX authenticates the socket with its existing pairing bearer
+  key (no new credential). The `/mcp` endpoint is localhost-only and requires
+  the vault's existing API auth (`src/bun/auth.ts`) — same story as the v2 REST
+  surface.
+- **If the bridge is down** (BEX not running / socket dropped): tools return a
+  structured `bridge_disconnected` error, never hang. Vault answers `/mcp`
+  regardless so the agent can always ask `bex_status` and get a truthful "BEX
+  unreachable".
+
+**Rejected alternative — native messaging host:** a stdio MCP binary registered
+as a Chrome native-messaging host. Works, but adds a second install/registration
+path and a new binary to ship; the vault channel already exists, is authed, and
+is running full-time on the dev machine this epic serves. Revisit only if we
+need the bridge without a vault install.
+
+---
+
+## Tool surface (v1)
+
+All tools namespaced `bex_`. Two tiers, both **off by default** (see Safety).
+
+### Tier 1 — read-only (enabled by the "Agent mode" toggle)
+
+| Tool | Returns | Notes |
+|---|---|---|
+| `bex_status` | extension version, device connected?, vault paired?, active EVM networkId, bridge uptime, SW restart count | the "is anything even alive" call |
+| `bex_accounts` | per-chain: `{ chain, networkId, address, pubkey/xpub, addressType }` — the **exact values handlers return to dApps** | must expose the raw shape (string vs array) — that's the point; would have caught bug #2 |
+| `bex_pending_requests` | approval queue: `{ id, method, params, origin, chain, requestedAt }` | source of truth is whatever `requireApproval` (`background/methods.ts:60`) queues for the side panel |
+| `bex_logs` | ring buffer of background logs + a structured provider request/response log; args: `{ pattern?, since?, limit? }` | new: a `providerLog` interceptor in `background/methods.ts` recording every injected request, response, and error **code** — would have caught bug #1 |
+| `bex_connected_sites` | origins with active provider connections + chains each has touched | |
+
+### Tier 2 — control (additionally requires the "Allow agent control" toggle)
+
+| Tool | Action | Notes |
+|---|---|---|
+| `bex_approve_request` | settle a pending approval id as approved | sends the same `eth_sign_response` runtime message the side panel sends — no parallel approval path, one choke point |
+| `bex_reject_request` | settle as rejected (dApp receives code 4001) | |
+| `bex_provider_request` | execute `{ chain, method, params, origin? }` through the same `handleXxxRequest` routing in `background/methods.ts` a page would hit | read-only methods (accounts, balances, chainId) run directly; signing/tx methods still enter `requireApproval` — the agent then approves via `bex_approve_request`, keeping one auditable path |
+| `bex_set_network` | switch active EVM network | |
+| `bex_revoke_site` | disconnect an origin | |
+
+**Explicitly out of scope for v1:** seed/xpriv/entropy access (never), pairing-key
+export (never), skipping device confirmation (the KeepKey's physical button
+remains the backstop for anything that signs — MCP cannot press it, by design),
+driving the side-panel UI itself (agent asserts via state, not pixels).
+
+---
+
+## Safety model
+
+- Both toggles live in the options page, persisted via `packages/storage`,
+  default **off**. Flipping either shows a persistent badge/banner ("Agent mode
+  active") so a human at the machine always knows.
+- Tier-2 tools hard-fail with a structured `agent_control_disabled` error when
+  the second toggle is off — not silently downgraded.
+- Everything is localhost + existing vault auth. No remote exposure; the vault
+  must not bind `/mcp` beyond loopback.
+- The provider log (`bex_logs`) must redact nothing *structural* but must never
+  log signed-tx raw bytes' private inputs (there are none — signing happens on
+  device — but keep the rule stated).
+- Signing still requires the physical device confirmation. Agent mode automates
+  the *extension's* consent, not the *device's*. This is the line: an agent can
+  approve what the side panel would approve, and nothing more.
+
+---
+
+## Phases — each ends in a testable state
+
+### Phase 1 — Bridge + read-only introspection
+**Build:** `src/bun/mcp.ts` (vault: Streamable HTTP endpoint, tool registry,
+session handling) · `ws /bex-bridge` upgrade handler (vault) ·
+`chrome-extension/src/background/mcpBridge.ts` (BEX: outbound WS, reconnect on
+SW wake, request/response envelope) · tools `bex_status`, `bex_accounts`,
+`bex_pending_requests`, `bex_connected_sites` · options-page "Agent mode"
+toggle · `providerLog` ring buffer + `bex_logs`.
+
+**Exit test (scriptable, no human):**
+```bash
+claude mcp add keepkey --transport http http://localhost:1646/mcp
+# then, in an agent session:
+# 1. tools/list returns the 6 tier-1/2 names (tier-2 present but disabled)
+# 2. bex_status → { deviceConnected: true, vaultPaired: true, bridge: "up" }
+# 3. bex_accounts → ETH address equals the one the side panel displays;
+#    THOR/UTXO entries expose their real shape (this is bug #2's regression test)
+# 4. Kill the BEX (disable extension) → bex_status returns bridge_disconnected
+#    within 10s; re-enable → bridge recovers without vault restart
+```
+
+### Phase 2 — Approval control
+**Build:** `bex_approve_request` / `bex_reject_request` wired through the
+`eth_sign_response` message path · "Allow agent control" toggle + banner ·
+structured `agent_control_disabled` error.
+
+**Exit test:** a fixture page (`tests/fixtures/agent-bridge.html`) that fires
+`wallet_addEthereumChain` and `eth_requestAccounts` on load:
+```
+1. Agent opens fixture page, polls bex_pending_requests → sees the request
+   with correct origin/method/params
+2. bex_reject_request → page's promise rejects with code 4001
+3. bex_approve_request on eth_requestAccounts → page receives accounts
+4. With control toggle OFF, both tools return agent_control_disabled and the
+   queue is untouched
+```
+(This is bug #1's regression environment: the agent can now *watch* the
+switch/add cascade and assert on error codes.)
+
+### Phase 3 — Drive the wallet end-to-end
+**Build:** `bex_provider_request`, `bex_set_network`, `bex_revoke_site`.
+
+**Exit test — the acceptance run for the whole epic:** an agent, alone, against
+a local swapspro dev server:
+```
+1. bex_provider_request eth_requestAccounts (origin: localhost:3000) → approve
+   via bex_approve_request → addresses returned
+2. Drive swapspro's connect flow; assert via bex_logs that connecting 9 chains
+   produces ZERO wallet_addEthereumChain requests for already-known networks
+3. Capture the exact pubkey payload swapspro sends to Pioneer /portfolio and
+   assert every pubkey is a non-empty string (bug #2, verified end-to-end)
+4. Balances render: agent asserts sidepanel state via swapspro, not pixels
+5. Full transcript of provider traffic available from bex_logs as the test
+   artifact
+```
+
+**The epic is done when the Phase-3 script runs green from a fresh
+`claude mcp add`, with the human's only involvement being the two options-page
+toggles and (for any signing test) the device button.**
+
+---
+
+## Implementation pointers (verified in-code this session)
+
+- `chrome-extension/src/background/methods.ts:60` — `requireApproval`: sets
+  badge, opens side panel, resolves on `eth_sign_response` runtime message or
+  timeout-reject. Both new approval tools and `bex_pending_requests` hang off
+  this one function; extend it, don't fork it.
+- `chrome-extension/src/background/methods.ts:~170-215` — per-chain
+  `handleXxxRequest` dispatch: the routing `bex_provider_request` should call
+  into, so agent traffic and page traffic take the identical path.
+- `chrome-extension/src/background/swapEventStream.ts` — existing vault event
+  stream; the bridge socket follows this lifecycle pattern.
+- `chrome-extension/src/background/index.ts` + `utils.ts` — pairing/init and
+  the `1646` client; bridge auth reuses the stored pairing key.
+- Vault REST/auth: `src/bun/rest-api.ts`, `src/bun/auth.ts` (vault repo) —
+  `/mcp` and `/bex-bridge` land beside the existing v2 surface.
+- Manifest (`chrome-extension/manifest.js`): no new permissions expected —
+  outbound WS to localhost is covered; verify against MV3 CSP during Phase 1.
+
+## Phase 1 implementation notes (2026-07-15, branch `feature/mcp-agent-bridge`)
+
+Shipped: vault `src/bun/mcp.ts` + `src/bun/bex-bridge.ts` + `rest-api.ts` wiring
+(vault repo, uncommitted — its tree is mid-hive-work); BEX `mcpBridge.ts`,
+`providerLog.ts`, `methods.ts` instrumentation, `agentModeStorage`, options
+toggle; exit test `scripts/test-mcp-bridge.mjs`.
+
+Deviations from the spec above:
+- **WS auth is `?token=<pairing key>`, not an Authorization header** — browser
+  `WebSocket` cannot set headers. Loopback-only socket, key still validated by
+  `auth.validate`.
+- **`POST /mcp` requires loopback, not a bearer key** — the exit test's bare
+  `claude mcp add` has no pairing key; the BEX-side Agent-mode toggle (default
+  off) is the actual gate on data. `/mcp` and `/bex-bridge` both reject
+  non-loopback callers (the vault otherwise binds 0.0.0.0).
+- **MCP protocol is hand-rolled** (initialize/ping/tools/list/tools/call, plain
+  JSON responses, no sessions/SSE — all optional per spec) instead of
+  `@modelcontextprotocol/sdk` — open question #1 resolved in favor of no new
+  vault dependency.
+- tools/list returns the **5 tier-1 tools only**; tier-2 names appear in
+  Phase 2 with the control toggle.
+
+## Open questions (decide at Phase boundaries, don't block Phase 1)
+
+1. MCP SDK on the vault side: `@modelcontextprotocol/sdk` server under Bun vs.
+   hand-rolled Streamable HTTP (the protocol surface we need is small). Try the
+   SDK first; fall back if Bun compat bites.
+2. Should `bex_logs` persist across SW restarts (chrome.storage ring) or is
+   in-memory + restart counter enough for v1? Start in-memory.
+3. Event push (MCP notifications for "new pending request") vs. agent polling.
+   v1: polling; the queue is small and agents poll fine.

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -15,6 +15,7 @@ import { resetTonState, prefetchTonAddress } from './chains/tonHandler';
 import { resetTronState, prefetchTronPubkey } from './chains/tronHandler';
 import { resetHiveState } from './chains/hiveHandler';
 import { handleWalletRequest } from './methods';
+import { initMcpBridge } from './mcpBridge';
 import { setApprovalBadge } from './popup';
 import { fetchJsonWithTimeout } from './fetchUtils';
 import { JsonRpcProvider, formatEther } from 'ethers';
@@ -1124,6 +1125,27 @@ function ensureStarted(): Promise<void> {
 setTimeout(() => {
   ensureStarted();
 }, 5000);
+
+// MCP agent bridge (EPIC_mcp_agent_bridge.md): module-load init means it
+// re-arms on every SW wake. No-op unless the options-page "Agent mode"
+// toggle is on.
+initMcpBridge({
+  getKeepKeyState: () => KEEPKEY_STATE,
+  walletRequest: async (chain: string, method: string, params: any[]) => {
+    if (!wallet.isInitialized()) await ensureStarted();
+    const requestInfo = {
+      id: crypto.randomUUID(),
+      method,
+      params,
+      chain,
+      siteUrl: 'mcp://agent',
+      href: 'mcp://agent',
+      scriptSource: 'MCP Agent Bridge',
+      requestTime: new Date().toISOString(),
+    };
+    return handleWalletRequest(requestInfo, chain, method, params, null, ADDRESS);
+  },
+});
 
 chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: any) => {
   (async () => {

--- a/chrome-extension/src/background/mcpBridge.ts
+++ b/chrome-extension/src/background/mcpBridge.ts
@@ -1,0 +1,206 @@
+/**
+ * mcpBridge — BEX side of the MCP agent bridge (EPIC_mcp_agent_bridge.md).
+ *
+ * When the options-page "Agent mode" toggle is ON, the background keeps one
+ * outbound WebSocket to the vault (ws://localhost:1646/bex-bridge, authed with
+ * the existing pairing key) and answers read-only introspection tool calls
+ * forwarded from the vault's POST /mcp endpoint:
+ *
+ *   {id, tool, args}  →  {id, result | error: {code, message}}
+ *
+ * Toggle OFF (the default) → no socket, no data exposed; the vault answers
+ * agents with bridge_disconnected. Reconnect lifecycle mirrors
+ * swapEventStream.ts (backoff, restart on SW wake via module-load init).
+ */
+
+import * as wallet from './wallet';
+import { agentModeStorage, keepKeyApiKeyStorage, web3ProviderStorage } from '@extension/storage';
+import { getLogs, getPendingRequests, getConnectedSites, SW_STARTED_AT } from './providerLog';
+
+const TAG = ' | mcpBridge | ';
+const BRIDGE_URL = 'ws://localhost:1646/bex-bridge';
+const RECONNECT_MAX_MS = 60_000;
+
+const KEEPKEY_STATE_NAMES: Record<number, string> = {
+  0: 'unknown',
+  1: 'disconnected',
+  2: 'connected',
+  3: 'busy',
+  4: 'errored',
+  5: 'paired',
+};
+
+// Chains whose request_accounts is a cache read (no device round-trip).
+const ACCOUNT_CHAINS = [
+  'ethereum',
+  'bitcoin',
+  'bitcoincash',
+  'dogecoin',
+  'litecoin',
+  'dash',
+  'thorchain',
+  'mayachain',
+  'cosmos',
+  'osmosis',
+  'ripple',
+];
+
+export interface McpBridgeDeps {
+  getKeepKeyState: () => number;
+  /** Routes through the same handleWalletRequest path page traffic takes. */
+  walletRequest: (chain: string, method: string, params: any[]) => Promise<any>;
+}
+
+let deps: McpBridgeDeps | null = null;
+let ws: WebSocket | null = null;
+let enabled = false;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectDelay = 5_000;
+let connectedAt: number | null = null;
+
+export function initMcpBridge(bridgeDeps: McpBridgeDeps): void {
+  deps = bridgeDeps;
+  const apply = (on: boolean | undefined) => {
+    enabled = !!on;
+    if (enabled) connect();
+    else disconnect();
+  };
+  agentModeStorage.subscribe(() => apply(agentModeStorage.getSnapshot() ?? undefined));
+  agentModeStorage.get().then(apply);
+}
+
+function disconnect(): void {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  if (ws) {
+    try {
+      ws.close();
+    } catch {
+      /* already closed */
+    }
+    ws = null;
+  }
+  connectedAt = null;
+  reconnectDelay = 5_000;
+}
+
+async function connect(): Promise<void> {
+  if (!enabled || ws) return;
+  const apiKey = await keepKeyApiKeyStorage.getApiKey();
+  if (!enabled || ws) return; // toggle raced the await
+  if (!apiKey) {
+    // Not paired yet — retry until pairing exists or the toggle goes off.
+    scheduleReconnect();
+    return;
+  }
+
+  // Browser WebSocket can't set an Authorization header — pairing key rides
+  // the query string on this loopback-only socket (vault validates it).
+  const socket = new WebSocket(`${BRIDGE_URL}?token=${encodeURIComponent(apiKey)}`);
+  ws = socket;
+
+  socket.onopen = () => {
+    if (ws !== socket) return;
+    console.log(TAG, 'bridge connected');
+    connectedAt = Date.now();
+    reconnectDelay = 5_000;
+  };
+
+  socket.onmessage = async event => {
+    let msg: any;
+    try {
+      msg = JSON.parse(String(event.data));
+    } catch {
+      return;
+    }
+    if (!msg?.id || !msg?.tool) return;
+    try {
+      const result = await executeTool(msg.tool, msg.args ?? {});
+      socket.send(JSON.stringify({ id: msg.id, result }));
+    } catch (e: any) {
+      socket.send(
+        JSON.stringify({
+          id: msg.id,
+          error: { code: e?.code ?? 'tool_error', message: e?.message || String(e) },
+        }),
+      );
+    }
+  };
+
+  socket.onclose = () => {
+    if (ws !== socket) return;
+    ws = null;
+    connectedAt = null;
+    scheduleReconnect();
+  };
+
+  socket.onerror = () => {
+    // onclose follows and handles reconnect
+  };
+}
+
+function scheduleReconnect(): void {
+  if (!enabled || reconnectTimer) return;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    void connect();
+  }, reconnectDelay);
+  reconnectDelay = Math.min(reconnectDelay * 2, RECONNECT_MAX_MS);
+}
+
+async function executeTool(tool: string, args: any): Promise<any> {
+  if (!deps) throw new Error('bridge not initialized');
+  switch (tool) {
+    case 'bex_status': {
+      const state = deps.getKeepKeyState();
+      const apiKey = await keepKeyApiKeyStorage.getApiKey();
+      const provider = await web3ProviderStorage.getWeb3Provider().catch(() => null);
+      return {
+        bridge: 'up',
+        version: chrome.runtime.getManifest().version,
+        keepkeyState: state,
+        keepkeyStateName: KEEPKEY_STATE_NAMES[state] ?? String(state),
+        deviceConnected: state === 2 || state === 3 || state === 5,
+        vaultPaired: !!apiKey,
+        walletInitialized: wallet.isInitialized(),
+        activeEvmNetwork: provider
+          ? { chainId: provider.chainId, networkId: provider.networkId, name: provider.name }
+          : null,
+        swStartedAt: SW_STARTED_AT,
+        bridgeConnectedAt: connectedAt,
+      };
+    }
+
+    case 'bex_accounts': {
+      const chains: string[] = Array.isArray(args?.chains) && args.chains.length ? args.chains : ACCOUNT_CHAINS;
+      const accounts = await Promise.all(
+        chains.map(async chain => {
+          try {
+            // The EXACT value a dApp gets from request_accounts — raw shape
+            // (string vs array vs nested array) deliberately preserved; this
+            // is the epic's bug-#2 regression surface.
+            const providerResponse = await deps!.walletRequest(chain, 'request_accounts', []);
+            return { chain, providerResponse };
+          } catch (e: any) {
+            return { chain, error: e?.message || String(e) };
+          }
+        }),
+      );
+      return { accounts, pubkeys: wallet.getPubkeys() };
+    }
+
+    case 'bex_pending_requests':
+      return { requests: getPendingRequests() };
+
+    case 'bex_connected_sites':
+      return { sites: getConnectedSites() };
+
+    case 'bex_logs':
+      return { swStartedAt: SW_STARTED_AT, entries: getLogs(args) };
+
+    default:
+      throw Object.assign(new Error(`unknown tool: ${tool}`), { code: 'unknown_tool' });
+  }
+}

--- a/chrome-extension/src/background/methods.ts
+++ b/chrome-extension/src/background/methods.ts
@@ -20,6 +20,7 @@ import { handleHiveRequest } from './chains/hiveHandler';
 import type { ProviderRpcError } from './utils';
 import { createProviderRpcError, formatUserError } from './utils';
 import { openSidePanel, setApprovalBadge } from './popup';
+import { recordProviderCall, recordSite, registerPending, settlePending } from './providerLog';
 
 const TAG = ' | METHODS | ';
 
@@ -117,6 +118,17 @@ const requireApproval = async function (
     setApprovalBadge(true);
     await openSidePanel(requestInfo);
 
+    // Mirror the in-memory approval queue for the MCP agent bridge
+    // (bex_pending_requests). Settled again on resolve/timeout below.
+    registerPending({
+      id: requestInfo.id,
+      method: method || requestInfo.method,
+      params: params ?? requestInfo.params,
+      origin: requestInfo.siteUrl || requestInfo.href || '',
+      chain,
+      requestedAt: Date.now(),
+    });
+
     // Wait for user's decision. Resolves on ANY of:
     //   - user approves/rejects in sidebar (eth_sign_response arrives)
     //   - APPROVAL_TIMEOUT_MS elapses without a response (treated as reject)
@@ -128,6 +140,7 @@ const requireApproval = async function (
         chrome.runtime.onMessage.removeListener(listener);
         if (timer != null) clearTimeout(timer);
         setApprovalBadge(false);
+        settlePending(requestInfo.id);
       };
 
       const listener = (message: any) => {
@@ -151,11 +164,45 @@ const requireApproval = async function (
     });
   } catch (e) {
     console.error(tag, e);
+    settlePending(requestInfo?.id);
     return { success: false }; // Return failure in case of error
   }
 };
 
+// Thin observability wrapper: every provider call (page- or agent-originated)
+// lands in the providerLog ring buffer with its result or error CODE — the
+// data bex_logs serves (EPIC_mcp_agent_bridge.md, bug #1).
 export const handleWalletRequest = async (
+  requestInfo: any,
+  chain: string,
+  method: string,
+  params: any[],
+  __KEEPKEY_WALLET: any,
+  ADDRESS: string,
+): Promise<any> => {
+  const startedAt = Date.now();
+  const origin = requestInfo?.siteUrl || requestInfo?.href || '';
+  recordSite(origin, chain);
+  try {
+    const result = await routeWalletRequest(requestInfo, chain, method, params, __KEEPKEY_WALLET, ADDRESS);
+    recordProviderCall({ ts: Date.now(), origin, chain, method, params, result, durationMs: Date.now() - startedAt });
+    return result;
+  } catch (error: any) {
+    recordProviderCall({
+      ts: Date.now(),
+      origin,
+      chain,
+      method,
+      params,
+      errorCode: error?.code,
+      errorMessage: error?.message || String(error),
+      durationMs: Date.now() - startedAt,
+    });
+    throw error;
+  }
+};
+
+const routeWalletRequest = async (
   requestInfo: any,
   chain: string,
   method: string,

--- a/chrome-extension/src/background/providerLog.test.ts
+++ b/chrome-extension/src/background/providerLog.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  recordProviderCall,
+  getLogs,
+  registerPending,
+  settlePending,
+  getPendingRequests,
+  recordSite,
+  getConnectedSites,
+} from './providerLog';
+
+const entry = (over: Partial<Parameters<typeof recordProviderCall>[0]> = {}) => ({
+  ts: Date.now(),
+  origin: 'https://dapp.test',
+  chain: 'ethereum',
+  method: 'eth_chainId',
+  params: [],
+  durationMs: 1,
+  ...over,
+});
+
+describe('providerLog ring buffer', () => {
+  it('records calls and filters by pattern (method, origin, errorMessage)', () => {
+    recordProviderCall(
+      entry({ method: 'wallet_switchEthereumChain', errorCode: -32002, errorMessage: 'already pending' }),
+    );
+    recordProviderCall(entry({ method: 'eth_requestAccounts' }));
+
+    expect(getLogs({ pattern: 'switchEthereum' })).toHaveLength(1);
+    expect(getLogs({ pattern: 'already pending' })[0].errorCode).toBe(-32002);
+    expect(getLogs({ pattern: 'no-such-thing' })).toHaveLength(0);
+  });
+
+  it('filters by since and caps by limit, newest last', () => {
+    const cutoff = Date.now() + 1000;
+    recordProviderCall(entry({ ts: cutoff + 1, method: 'later_call' }));
+    const since = getLogs({ since: cutoff });
+    expect(since.every(e => e.ts >= cutoff)).toBe(true);
+
+    for (let i = 0; i < 10; i++) recordProviderCall(entry({ method: `m${i}` }));
+    const limited = getLogs({ limit: 3 });
+    expect(limited).toHaveLength(3);
+    expect(limited[2].method).toBe('m9');
+  });
+
+  it('caps the buffer at 500 entries', () => {
+    for (let i = 0; i < 600; i++) recordProviderCall(entry());
+    expect(getLogs({ limit: 10_000 }).length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe('pending request registry', () => {
+  it('registers and settles pending approvals', () => {
+    registerPending({
+      id: 'req-1',
+      method: 'personal_sign',
+      params: ['hi'],
+      origin: 'https://dapp.test',
+      chain: 'ethereum',
+      requestedAt: Date.now(),
+    });
+    expect(getPendingRequests().map(r => r.id)).toContain('req-1');
+    settlePending('req-1');
+    expect(getPendingRequests().map(r => r.id)).not.toContain('req-1');
+  });
+});
+
+describe('connected sites', () => {
+  it('aggregates chains per origin and ignores empty origins', () => {
+    recordSite('https://swaps.pro', 'ethereum');
+    recordSite('https://swaps.pro', 'thorchain');
+    recordSite('', 'ethereum');
+
+    const site = getConnectedSites().find(s => s.origin === 'https://swaps.pro');
+    expect(site?.chains.sort()).toEqual(['ethereum', 'thorchain']);
+    expect(getConnectedSites().some(s => s.origin === '')).toBe(false);
+  });
+});

--- a/chrome-extension/src/background/providerLog.ts
+++ b/chrome-extension/src/background/providerLog.ts
@@ -1,0 +1,101 @@
+/**
+ * providerLog — in-memory observability state for the MCP agent bridge
+ * (EPIC_mcp_agent_bridge.md). Three registries, all fed from methods.ts:
+ *
+ *  - a ring buffer of every provider request/response/error (bex_logs)
+ *  - the live approval queue mirrored out of requireApproval (bex_pending_requests)
+ *  - origins that have made provider requests + chains touched (bex_connected_sites)
+ *
+ * ponytail: in-memory only — wiped on MV3 service-worker restart. bex_status
+ * exposes swStartedAt so agents can detect the wipe; move to chrome.storage
+ * if cross-restart logs prove necessary (epic open question #2).
+ */
+
+export interface ProviderLogEntry {
+  ts: number; // ms epoch, request completion time
+  origin: string;
+  chain: string;
+  method: string;
+  params: unknown;
+  result?: unknown;
+  errorCode?: number | string;
+  errorMessage?: string;
+  durationMs: number;
+}
+
+export interface PendingRequest {
+  id: string;
+  method: string;
+  params: unknown;
+  origin: string;
+  chain: string;
+  requestedAt: number;
+}
+
+const MAX_LOG_ENTRIES = 500;
+const MAX_RESULT_CHARS = 2000; // keep the ring buffer bounded in memory, not just in length
+
+export const SW_STARTED_AT = Date.now();
+
+const logBuffer: ProviderLogEntry[] = [];
+const pendingRequests = new Map<string, PendingRequest>();
+const connectedSites = new Map<string, { chains: Set<string>; firstSeen: number; lastSeen: number }>();
+
+const clip = (v: unknown): unknown => {
+  const s = JSON.stringify(v);
+  if (s && s.length > MAX_RESULT_CHARS) return `[clipped ${s.length} chars] ${s.slice(0, MAX_RESULT_CHARS)}`;
+  return v;
+};
+
+export function recordProviderCall(entry: ProviderLogEntry): void {
+  logBuffer.push({
+    ...entry,
+    params: clip(entry.params),
+    result: entry.result === undefined ? undefined : clip(entry.result),
+  });
+  if (logBuffer.length > MAX_LOG_ENTRIES) logBuffer.splice(0, logBuffer.length - MAX_LOG_ENTRIES);
+}
+
+export function getLogs(filter?: { pattern?: string; since?: number; limit?: number }): ProviderLogEntry[] {
+  let out = logBuffer;
+  if (filter?.since) out = out.filter(e => e.ts >= filter.since!);
+  if (filter?.pattern) {
+    const re = new RegExp(filter.pattern, 'i');
+    out = out.filter(e => re.test(e.method) || re.test(e.origin) || re.test(e.chain) || re.test(e.errorMessage ?? ''));
+  }
+  const limit = filter?.limit ?? 100;
+  return out.slice(-limit);
+}
+
+export function registerPending(req: PendingRequest): void {
+  pendingRequests.set(req.id, req);
+}
+
+export function settlePending(id: string): void {
+  pendingRequests.delete(id);
+}
+
+export function getPendingRequests(): PendingRequest[] {
+  return [...pendingRequests.values()];
+}
+
+export function recordSite(origin: string, chain: string): void {
+  if (!origin) return;
+  const now = Date.now();
+  const site = connectedSites.get(origin);
+  if (site) {
+    site.chains.add(chain);
+    site.lastSeen = now;
+  } else {
+    connectedSites.set(origin, { chains: new Set([chain]), firstSeen: now, lastSeen: now });
+  }
+}
+
+export function getConnectedSites(): Array<{ origin: string; chains: string[]; firstSeen: number; lastSeen: number }> {
+  return [...connectedSites.entries()].map(([origin, s]) => ({
+    origin,
+    chains: [...s.chains],
+    firstSeen: s.firstSeen,
+    lastSeen: s.lastSeen,
+  }));
+}

--- a/packages/storage/lib/customStorage.ts
+++ b/packages/storage/lib/customStorage.ts
@@ -97,6 +97,14 @@ const createApiKeyStorage = (): ApiKeyStorage => {
 
 export const keepKeyApiKeyStorage = createApiKeyStorage();
 
+// Agent mode (MCP bridge, EPIC_mcp_agent_bridge.md): when on, the background
+// connects to the vault's /bex-bridge socket and answers read-only
+// introspection tools. Default OFF.
+export const agentModeStorage = createStorage<boolean>('keepkey-agent-mode', false, {
+  storageType: StorageType.Local,
+  liveUpdate: true,
+});
+
 // Create Event Storage
 const createEventStorage = (key: string): EventStorage => {
   const storage = createStorage<Event[]>(key, [], {

--- a/packages/storage/lib/index.ts
+++ b/packages/storage/lib/index.ts
@@ -1,6 +1,7 @@
 import { createStorage, StorageType, type BaseStorage, SessionAccessLevel } from './base';
 import {
   keepKeyApiKeyStorage,
+  agentModeStorage,
   requestStorage,
   approvalStorage,
   completedStorage,
@@ -25,6 +26,7 @@ export type { DeviceInfo, StoredPubkeys, PubkeyStorageType } from './pubkeyStora
 export {
   chainIdStorage,
   keepKeyApiKeyStorage,
+  agentModeStorage,
   web3ProviderStorage,
   requestStorage,
   approvalStorage,

--- a/pages/options/src/Options.tsx
+++ b/pages/options/src/Options.tsx
@@ -1,11 +1,12 @@
 import '@src/Options.css';
 import { useEffect, useState } from 'react';
 import { withErrorBoundary, withSuspense } from '@extension/shared';
-import { exampleSidebarStorage } from '@extension/storage'; // Re-import the storage
+import { exampleSidebarStorage, agentModeStorage } from '@extension/storage'; // Re-import the storage
 import type { DeviceInfo } from '@extension/storage';
 
 const Options = () => {
   const [openSidebar, setOpenSidebar] = useState<boolean>(true);
+  const [agentMode, setAgentMode] = useState<boolean>(false);
   const [cacheEnabled, setCacheEnabledState] = useState<boolean>(true);
   const [hasCachedPubkeys, setHasCachedPubkeys] = useState<boolean>(false);
   const [cachedDeviceInfo, setCachedDeviceInfo] = useState<DeviceInfo | null>(null);
@@ -25,6 +26,16 @@ const Options = () => {
     };
     fetchSidebarPreference();
   }, []);
+
+  useEffect(() => {
+    agentModeStorage.get().then(value => setAgentMode(!!value));
+  }, []);
+
+  const handleToggleAgentMode = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.checked;
+    setAgentMode(value);
+    await agentModeStorage.set(value);
+  };
 
   // Fetch cache status on component mount
   useEffect(() => {
@@ -108,6 +119,18 @@ const Options = () => {
       </section>
 
       <section>
+        <h2>Agent Mode (MCP)</h2>
+        <p className="description">
+          Lets AI agents on this computer inspect the extension (accounts, pending approvals, provider logs) through the
+          vault's MCP endpoint at localhost:1646/mcp. Read-only: agents cannot approve requests or sign anything.
+        </p>
+        <label>
+          <input type="checkbox" checked={agentMode} onChange={handleToggleAgentMode} />
+          Enable Agent mode (read-only introspection)
+        </label>
+      </section>
+
+      <section>
         <h2>View-Only Mode Cache</h2>
         <p className="description">
           Cache your device's public keys to view balances and portfolio when your KeepKey is not connected. Signing
@@ -131,7 +154,9 @@ const Options = () => {
             </div>
           )}
 
-          {!hasCachedPubkeys && cacheEnabled && <p className="info">No cached pubkeys. Connect your device to enable view-only mode.</p>}
+          {!hasCachedPubkeys && cacheEnabled && (
+            <p className="info">No cached pubkeys. Connect your device to enable view-only mode.</p>
+          )}
         </div>
       </section>
     </div>

--- a/scripts/test-mcp-bridge.mjs
+++ b/scripts/test-mcp-bridge.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Phase-1 exit test for the MCP agent bridge (EPIC_mcp_agent_bridge.md).
+ *
+ * Preconditions (human, one-time): vault running on :1646, extension loaded,
+ * options-page "Agent mode" toggle ON.
+ *
+ *   node scripts/test-mcp-bridge.mjs
+ *
+ * Exits 0 when the vault serves MCP, tier-1 tools are listed, and bex_status
+ * answers truthfully through the bridge (or truthfully reports bridge down).
+ */
+
+const MCP_URL = 'http://localhost:1646/mcp';
+const TIER1_TOOLS = ['bex_status', 'bex_accounts', 'bex_pending_requests', 'bex_connected_sites', 'bex_logs'];
+
+let nextId = 1;
+async function rpc(method, params) {
+  const res = await fetch(MCP_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: nextId++, method, ...(params ? { params } : {}) }),
+  });
+  if (!res.ok) throw new Error(`${method}: HTTP ${res.status}`);
+  const body = await res.json();
+  if (body.error) throw new Error(`${method}: rpc error ${body.error.code} ${body.error.message}`);
+  return body.result;
+}
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error(`FAIL: ${msg}`);
+    process.exit(1);
+  }
+  console.log(`ok: ${msg}`);
+}
+
+const init = await rpc('initialize', {
+  protocolVersion: '2025-03-26',
+  capabilities: {},
+  clientInfo: { name: 'exit-test', version: '0' },
+});
+assert(init.serverInfo?.name === 'keepkey-vault', 'initialize returns keepkey-vault serverInfo');
+
+const { tools } = await rpc('tools/list');
+const names = tools.map(t => t.name);
+for (const t of TIER1_TOOLS) assert(names.includes(t), `tools/list includes ${t}`);
+
+const call = await rpc('tools/call', { name: 'bex_status', arguments: {} });
+const status = JSON.parse(call.content[0].text);
+console.log('bex_status →', status);
+assert(status.bridge === 'up' || status.bridge === 'down', 'bex_status reports bridge state truthfully');
+if (status.bridge === 'down') {
+  console.log('bridge is DOWN — enable Agent mode in the extension options page and re-run for the full pass');
+  process.exit(2);
+}
+assert(typeof status.version === 'string' && status.version.length > 0, 'bex_status has extension version');
+assert(typeof status.keepkeyState === 'number', 'bex_status has keepkeyState');
+
+// bug #2 regression surface: raw per-chain request_accounts shapes are exposed
+const acct = await rpc('tools/call', { name: 'bex_accounts', arguments: { chains: ['ethereum', 'thorchain'] } });
+const accounts = JSON.parse(acct.content[0].text);
+console.log('bex_accounts →', JSON.stringify(accounts.accounts, null, 2));
+assert(Array.isArray(accounts.accounts) && accounts.accounts.length === 2, 'bex_accounts returns per-chain entries');
+
+console.log('\nPhase 1 exit test PASSED');


### PR DESCRIPTION
Client side of the MCP agent bridge (vault side: keepkey-vault #360, merged). Required for MCP testing to function — without it the vault's `/mcp` has nothing to forward to.

## What
- `background/mcpBridge.ts` — the BEX background worker opens ONE outbound WebSocket to the vault (`ws://localhost:1646/bex-bridge`), authenticated with its existing pairing key via `?token=` (browser WS can't set an Authorization header). It answers the tool calls the vault forwards from POST `/mcp`.
- Tier-1 READ-ONLY introspection tools executed in the extension: `bex_status`, `bex_accounts`, `bex_pending_requests`, `bex_connected_sites`, `bex_logs`.
- `EPIC_mcp_agent_bridge.md` (design) + `scripts/test-mcp-bridge.mjs` (bridge smoke, exits 0 on pass / 2 if the bridge reports down).

## Auth / security (mirrors the merged vault side)
- `/bex-bridge` (this client's connection): loopback + pairing-token gated (unchanged).
- `/mcp` (the agent's connection, vault-side): now bearer-authed with the same pairing keys + browser-excluded (Origin/Sec-Fetch reject). No client change needed for that.
- The BEX **'Agent mode' toggle (default off)** gates all data-returning tools — with it off, tools reject and nothing leaks.

## Verify (needs the user: vault rebuild + extension reload)
1. Rebuild/restart the vault from develop (has #360); reload the extension from this branch's `dist/`.
2. Flip 'Enable Agent mode' in the extension options.
3. `node scripts/test-mcp-bridge.mjs` (0 = pass, 2 = bridge down).
4. Optionally: `claude mcp add keepkey --transport http http://localhost:1646/mcp --header "Authorization: Bearer <pairing-key>"` and call `bex_status`.

`make type-check` 15/15, `make test` green.