### PR TITLE
feat(mcp): browser-driving tools — let agents drive the wallet's real Chrome

### DIFF
--- a/HANDOFF_vault_mcp_dumb_pipe.md
+++ b/HANDOFF_vault_mcp_dumb_pipe.md
@@ -1,0 +1,104 @@
+# HANDOFF → vault: make `/mcp` a dumb pipe (serve the BEX's catalog, pass content through)
+
+**From:** keepkey-client, branch `feature/mcp-browser-driving`
+**To:** `/Users/highlander/WebstormProjects/keepkey-stack/projects/keepkey-vault-v11/projects/keepkey-vault`
+**File:** `src/bun/mcp.ts` (only — `bex-bridge.ts` needs nothing, it's already tool-agnostic)
+**Size:** ~20 lines. One time, forever.
+
+---
+
+## Why
+
+`src/bun/mcp.ts:38` hardcodes the tool catalog in the vault, and `:158` wraps every
+tool result as `{type:'text'}`. Two consequences, both blocking:
+
+1. **Every new BEX tool is a cross-repo change.** The client branch adds nine
+   browser-driving tools (`bex_snapshot`, `bex_click`, `bex_navigate`, …). With
+   the catalog in the vault, `tools/list` never mentions them and `tools/call`
+   rejects them at the `TOOL_NAMES` guard (`:155`) before the bridge is even
+   consulted. Every future tool would repeat this dance.
+2. **Screenshots are impossible.** MCP returns images as
+   `{type:'image', data, mimeType}` content blocks. The vault can only emit text,
+   so `bex_screenshot` has nowhere to put its JPEG.
+
+The bridge itself is already right: `callBex(tool, args)` in `bex-bridge.ts` does
+not care what the tool is. Only `mcp.ts` is coupled. Fix it once and the
+extension owns its entire tool surface — every subsequent tool ships in
+keepkey-client alone, with no vault release.
+
+## Change 1 — `tools/list` proxies to the BEX
+
+The BEX answers a new `bex_list_tools` call with `{tools: [...]}` (already
+implemented and merged-ready in `chrome-extension/src/background/mcpBridge.ts`).
+
+```ts
+    case 'tools/list': {
+      // The BEX owns its catalog; we serve whatever it reports. This is what
+      // keeps new tools a one-repo change (HANDOFF_vault_mcp_dumb_pipe.md).
+      try {
+        const { tools } = (await callBex('bex_list_tools', {})) as { tools: unknown[] }
+        return rpcResult(id, { tools }, cors)
+      } catch {
+        // Bridge down (BEX closed, or Agent mode off) — serve the static
+        // fallback so `claude mcp add` and tools/list still succeed and the
+        // agent can reach bex_status to find out why.
+        return rpcResult(id, { tools: FALLBACK_TOOLS }, cors)
+      }
+    }
+```
+
+Rename the existing `const TOOLS` to `FALLBACK_TOOLS` and leave its five tier-1
+entries as-is — bridge-down is the only path that reads it now. Add a comment
+that it's a fallback and **not** the source of truth, so nobody adds tools there
+out of habit.
+
+## Change 2 — `tools/call` passes content blocks through
+
+```ts
+    case 'tools/call': {
+      const name = params?.name
+      const args = params?.arguments ?? {}
+      try {
+        const result = (await callBex(name, args)) as any
+        // The BEX may answer with MCP content blocks already (bex_snapshot
+        // returns pre-formatted text; bex_screenshot returns an image). Pass
+        // those through untouched — JSON-stringifying them would double-encode
+        // the text and mangle the image.
+        if (result && Array.isArray(result.content)) return rpcResult(id, result, cors)
+        return rpcResult(id, { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] }, cors)
+      } catch (e: any) {
+        // ... unchanged
+      }
+    }
+```
+
+## Change 3 — drop the `TOOL_NAMES` guard
+
+Delete `const TOOL_NAMES` (`:87`) and the `if (!TOOL_NAMES.has(name))` check
+(`:155`). The vault can no longer know the valid names, and it doesn't need to:
+`executeTool`'s `default` branch in the BEX already throws
+`{code: 'unknown_tool'}`, which surfaces to the agent as an `isError` result via
+the existing catch. One rejection path, in the process that actually owns the
+catalog.
+
+## Do NOT change
+
+- **Auth** — `/mcp` stays bearer-authed + loopback-only + browser-excluded. The
+  browser tools make this *more* important, not less: `bex_click` can drive any
+  page in the user's real Chrome, including a logged-in exchange. The BEX-side
+  "Agent mode" toggle (default off) remains the gate on the tools doing anything.
+- **`CALL_TIMEOUT_MS = 30_000`** (`bex-bridge.ts:25`) — still adequate.
+  `bex_navigate` is the longest tool and self-caps its page-load wait at 20s.
+
+## Verifying
+
+From the client repo, with the vault running and Agent mode ON:
+
+```bash
+KEEPKEY_API_KEY=<pairing key> node scripts/test-mcp-bridge.mjs
+```
+
+The script asserts `tools/list` now includes the browser tools alongside tier-1,
+and that `bex_screenshot` comes back as an `image` content block. It fails
+loudly against an unpatched vault, so it doubles as the check that this handoff
+landed.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SHELL := /bin/bash
 .PHONY: help build build-firefox dev dev-firefox zip zip-firefox \
         install reinstall clean clean-bundle clean-turbo clean-deps \
         lint lint-fix prettier type-check test e2e e2e-firefox \
-        bump
+        test-mcp test-mcp-browser bump
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*##"; printf "targets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  %-18s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -76,6 +76,12 @@ type-check: ## Run TypeScript type-check across all packages
 
 test: ## Run unit tests (vitest), same as CI
 	pnpm test
+
+test-mcp: ## MCP agent-bridge exit test — needs vault on :1646, Agent mode ON, KEEPKEY_API_KEY
+	node scripts/test-mcp-bridge.mjs
+
+test-mcp-browser: ## Browser-driving tools exit test — same prereqs; opens/closes one tab
+	node scripts/test-browser-tools.mjs
 
 e2e: ## End-to-end tests (Chrome) — needs a connected KeepKey
 	pnpm e2e

--- a/chrome-extension/src/background/browserTools.ts
+++ b/chrome-extension/src/background/browserTools.ts
@@ -1,0 +1,367 @@
+/**
+ * browserTools — the `bex_*` browser-driving MCP tools.
+ *
+ * Why these live in the extension rather than in a Playwright/Puppeteer MCP: the
+ * whole point of this extension is the wallet, and a launched-fresh browser has
+ * no wallet in it. Driving the user's REAL Chrome means the agent tests the dApp
+ * against the real extension, the real vault pairing and the real device — and
+ * the existing bex_pending_requests / bex_logs tools observe the same session
+ * from the inside. That combination is the thing no general-purpose browser MCP
+ * can do, and it's the only reason this is worth building at all.
+ *
+ * ponytail: Playwright/Puppeteer are not options here even if we wanted them —
+ * the background bundles to one IIFE with no Node builtins (no `net`), so they
+ * cannot run in-extension at all. chrome.tabs + a content script cover this with
+ * zero new dependencies and, notably, zero new permissions: `<all_urls>` and
+ * `tabs` are already granted (manifest.js:39-40) and the content script is
+ * already at document_start on every http/https page.
+ *
+ * Contract with the DOM half (pages/content/src/agentDom.ts): one message per
+ * op, refs minted page-side. See that file for why refs beat selectors.
+ */
+
+// captureVisibleTab captures at devicePixelRatio, so a retina display yields a
+// 2560px-wide image — and Claude bills images by PIXELS, not bytes (~w*h/750
+// tokens). Downscaling to 1024 wide is a ~4x token cut for no practical loss of
+// legibility. This is the single biggest token lever in the whole tool set.
+const SCREENSHOT_MAX_WIDTH = 1024;
+const SCREENSHOT_QUALITY = 60;
+const LOAD_TIMEOUT_MS = 20_000;
+
+const err = (code: string, message: string) => Object.assign(new Error(message), { code });
+
+/** MCP content blocks — the vault passes these through verbatim (see HANDOFF). */
+type Content = { content: Array<Record<string, unknown>> };
+const text = (t: string): Content => ({ content: [{ type: 'text', text: t }] });
+
+export const BROWSER_TOOLS = [
+  {
+    name: 'bex_tabs',
+    description:
+      "List, create, close, or focus browser tabs in the user's real Chrome. action=list returns each tab's id, url, title and whether it is active.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: { type: 'string', enum: ['list', 'create', 'close', 'select'], description: 'Default: list' },
+        tabId: { type: 'number', description: 'Target tab for close/select' },
+        url: { type: 'string', description: 'URL for create' },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'bex_navigate',
+    description: 'Navigate a tab to a URL and wait for it to finish loading. Omit tabId to use the active tab.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string' },
+        tabId: { type: 'number' },
+      },
+      required: ['url'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'bex_snapshot',
+    description:
+      'Accessibility snapshot of the page: every visible interactive element with a stable [ref=eN] handle, plus headings for orientation. THIS is what you act on — pass a ref to bex_click / bex_type / bex_select. Refs are re-minted on each snapshot, so re-snapshot after anything that changes the page.',
+    inputSchema: {
+      type: 'object',
+      properties: { tabId: { type: 'number' } },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'bex_find',
+    description:
+      'Search the page snapshot for elements whose accessible name matches, returning only the hits with their refs. Use this instead of bex_snapshot when you already know what you are looking for — it keeps a large page out of your context.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string', description: 'Substring (case-insensitive) or regex source if regex=true' },
+        regex: { type: 'boolean' },
+        tabId: { type: 'number' },
+      },
+      required: ['text'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'bex_click',
+    description:
+      'Click an element by its snapshot ref. Dispatches a full pointer sequence, so modal/dropdown kits that listen on pointerdown work.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'A ref from the latest bex_snapshot, e.g. "e12"' },
+        element: {
+          type: 'string',
+          description: 'Human-readable description of what you are clicking, for the audit trail',
+        },
+        tabId: { type: 'number' },
+      },
+      required: ['ref', 'element'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'bex_type',
+    description:
+      'Type text into a textbox by its snapshot ref, replacing any current value. Set submit=true to press Enter afterwards.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        element: { type: 'string', description: 'Human-readable description of the field' },
+        text: { type: 'string' },
+        submit: { type: 'boolean' },
+        tabId: { type: 'number' },
+      },
+      required: ['ref', 'element', 'text'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'bex_select',
+    description: 'Choose an option in a <select> by its snapshot ref.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string' },
+        element: { type: 'string' },
+        value: { type: 'string' },
+        tabId: { type: 'number' },
+      },
+      required: ['ref', 'element', 'value'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'bex_read_page',
+    description:
+      'Rendered text of the page (defaults to <main>, else <body>). Use this to assert on content — balances, error banners, quoted amounts. Scope with a CSS selector to keep it small.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        selector: { type: 'string', description: 'CSS selector to scope the read' },
+        maxChars: { type: 'number', description: 'Default 10000' },
+        tabId: { type: 'number' },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'bex_screenshot',
+    description:
+      "JPEG of the tab's visible viewport, for VISUAL verification only — you cannot act on a screenshot. Use bex_snapshot to find things to click. Focuses the tab as a side effect (Chrome can only capture a visible tab).",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: { type: 'number' },
+        quality: { type: 'number', description: 'JPEG quality 1-100, default 60' },
+      },
+      additionalProperties: false,
+    },
+  },
+];
+
+async function activeTab(): Promise<chrome.tabs.Tab> {
+  const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  if (!tab?.id) throw err('no_active_tab', 'no active tab in the last focused window');
+  return tab;
+}
+
+async function resolveTab(tabId?: number): Promise<chrome.tabs.Tab> {
+  if (tabId == null) return activeTab();
+  try {
+    return await chrome.tabs.get(tabId);
+  } catch {
+    throw err('tab_not_found', `no tab with id ${tabId}`);
+  }
+}
+
+/** Ask the page-side agentDom to do something, and normalize its failures. */
+async function dom(tabId: number, op: string, payload: Record<string, unknown> = {}): Promise<any> {
+  let res: any;
+  try {
+    res = await chrome.tabs.sendMessage(tabId, { type: 'BEX_AGENT_DOM', op, ...payload });
+  } catch {
+    // No content script in this tab. Either it predates the extension load, or
+    // it's a chrome:// / Web Store / PDF page where content scripts never run.
+    throw err(
+      'no_content_script',
+      `cannot reach tab ${tabId} — reload the page (or use bex_navigate); chrome:// and Web Store pages can never be driven`,
+    );
+  }
+  if (!res) throw err('no_content_script', `tab ${tabId} did not answer — reload the page`);
+  if (!res.ok) throw err(res.code ?? 'dom_error', res.message ?? 'DOM operation failed');
+  return res.data;
+}
+
+/**
+ * Resolve once `tabId` finishes loading.
+ *
+ * Call this BEFORE triggering the navigation — the listener attaches
+ * synchronously, so starting the wait first is what closes the race where a
+ * fast page (cache hit, localhost) fires `complete` before we're listening and
+ * strands us on the timeout.
+ *
+ * `settledIsDone` is for a freshly created tab, which may already be finished by
+ * the time we learn its id. Do NOT set it for a navigate: there the OLD page is
+ * still `complete`, and we'd resolve instantly on the page we're leaving.
+ */
+function waitForLoad(tabId: number, { settledIsDone = false } = {}): Promise<void> {
+  return new Promise(resolve => {
+    const done = () => {
+      chrome.tabs.onUpdated.removeListener(listener);
+      clearTimeout(timer);
+      resolve();
+    };
+    // Resolve rather than reject on timeout: a page that never fires `complete`
+    // (long-polling, hung analytics beacon) is usually still perfectly drivable,
+    // and failing the navigate outright would be worse than proceeding.
+    const timer = setTimeout(done, LOAD_TIMEOUT_MS);
+    const listener = (id: number, info: chrome.tabs.TabChangeInfo) => {
+      if (id === tabId && info.status === 'complete') done();
+    };
+    chrome.tabs.onUpdated.addListener(listener);
+    if (settledIsDone) {
+      chrome.tabs
+        .get(tabId)
+        .then(t => {
+          if (t.status === 'complete') done();
+        })
+        .catch(done); // tab vanished — nothing left to wait for
+    }
+  });
+}
+
+/** Render a snapshot as indented text — far cheaper than JSON, which repeats every key. */
+function formatSnapshot(snap: { url: string; title: string; nodes: any[] }): string {
+  const lines = [`page ${snap.url} — ${JSON.stringify(snap.title)}`];
+  for (const n of snap.nodes) {
+    let line = `- ${n.role} ${JSON.stringify(n.name)}`;
+    if (n.ref) line += ` [ref=${n.ref}]`;
+    if (n.level) line += ` [level=${n.level}]`;
+    if (n.value) line += ` value=${JSON.stringify(n.value)}`;
+    if (n.checked != null) line += n.checked ? ' [checked]' : ' [unchecked]';
+    if (n.disabled) line += ' [disabled]';
+    lines.push(line);
+  }
+  if (snap.nodes.length === 0) lines.push('(no visible interactive elements — page may still be loading)');
+  return lines.join('\n');
+}
+
+async function screenshot(tab: chrome.tabs.Tab, quality: number): Promise<Content> {
+  // Chrome can only capture the ACTIVE tab of a window, so focus it first. This
+  // is a visible side effect and is called out in the tool description.
+  if (!tab.active && tab.id != null) await chrome.tabs.update(tab.id, { active: true });
+  const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId!, { format: 'jpeg', quality });
+
+  const binary = atob(dataUrl.split(',')[1]);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+  const bitmap = await createImageBitmap(new Blob([bytes], { type: 'image/jpeg' }));
+  const scale = Math.min(1, SCREENSHOT_MAX_WIDTH / bitmap.width);
+  const canvas = new OffscreenCanvas(Math.round(bitmap.width * scale), Math.round(bitmap.height * scale));
+  canvas.getContext('2d')!.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+  bitmap.close();
+
+  const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: quality / 100 });
+  const out = new Uint8Array(await blob.arrayBuffer());
+  let str = '';
+  for (let i = 0; i < out.length; i++) str += String.fromCharCode(out[i]);
+
+  return { content: [{ type: 'image', data: btoa(str), mimeType: 'image/jpeg' }] };
+}
+
+export function isBrowserTool(name: string): boolean {
+  return BROWSER_TOOLS.some(t => t.name === name);
+}
+
+export async function executeBrowserTool(tool: string, args: any): Promise<any> {
+  switch (tool) {
+    case 'bex_tabs': {
+      const action = args?.action ?? 'list';
+      if (action === 'create') {
+        const tab = await chrome.tabs.create({ url: args?.url, active: true });
+        if (args?.url && tab.id != null) await waitForLoad(tab.id, { settledIsDone: true });
+        return { tabId: tab.id, url: tab.url };
+      }
+      if (action === 'close') {
+        const tab = await resolveTab(args?.tabId);
+        await chrome.tabs.remove(tab.id!);
+        return { closed: tab.id };
+      }
+      if (action === 'select') {
+        const tab = await resolveTab(args?.tabId);
+        await chrome.tabs.update(tab.id!, { active: true });
+        await chrome.windows.update(tab.windowId!, { focused: true });
+        return { selected: tab.id };
+      }
+      const tabs = await chrome.tabs.query({});
+      return {
+        tabs: tabs.map(t => ({ tabId: t.id, url: t.url, title: t.title, active: t.active, windowId: t.windowId })),
+      };
+    }
+
+    case 'bex_navigate': {
+      if (!args?.url) throw err('bad_args', 'url is required');
+      const tab = await resolveTab(args?.tabId);
+      const loaded = waitForLoad(tab.id!); // start listening BEFORE navigating
+      await chrome.tabs.update(tab.id!, { url: args.url });
+      await loaded;
+      const after = await chrome.tabs.get(tab.id!);
+      return { tabId: after.id, url: after.url, title: after.title };
+    }
+
+    case 'bex_snapshot': {
+      const tab = await resolveTab(args?.tabId);
+      return text(formatSnapshot(await dom(tab.id!, 'snapshot')));
+    }
+
+    case 'bex_find': {
+      const tab = await resolveTab(args?.tabId);
+      const snap = await dom(tab.id!, 'find', { text: args?.text, regex: !!args?.regex });
+      if (snap.nodes.length === 0) {
+        return text(`no elements match ${JSON.stringify(args?.text)} on ${snap.url}`);
+      }
+      return text(formatSnapshot(snap));
+    }
+
+    case 'bex_click': {
+      const tab = await resolveTab(args?.tabId);
+      if (!args?.ref) throw err('bad_args', 'ref is required');
+      return dom(tab.id!, 'click', { ref: args.ref });
+    }
+
+    case 'bex_type': {
+      const tab = await resolveTab(args?.tabId);
+      if (!args?.ref) throw err('bad_args', 'ref is required');
+      return dom(tab.id!, 'type', { ref: args.ref, text: args.text, submit: !!args.submit });
+    }
+
+    case 'bex_select': {
+      const tab = await resolveTab(args?.tabId);
+      if (!args?.ref) throw err('bad_args', 'ref is required');
+      return dom(tab.id!, 'select', { ref: args.ref, value: args.value });
+    }
+
+    case 'bex_read_page': {
+      const tab = await resolveTab(args?.tabId);
+      const res = await dom(tab.id!, 'read', { selector: args?.selector, maxChars: args?.maxChars });
+      return text(res.truncated ? `${res.text}\n\n[truncated — raise maxChars or scope with selector]` : res.text);
+    }
+
+    case 'bex_screenshot': {
+      const tab = await resolveTab(args?.tabId);
+      const quality = Math.min(100, Math.max(1, Number(args?.quality) || SCREENSHOT_QUALITY));
+      return screenshot(tab, quality);
+    }
+
+    default:
+      throw err('unknown_tool', `unknown browser tool: ${tool}`);
+  }
+}

--- a/chrome-extension/src/background/mcpBridge.ts
+++ b/chrome-extension/src/background/mcpBridge.ts
@@ -16,6 +16,7 @@
 import * as wallet from './wallet';
 import { agentModeStorage, keepKeyApiKeyStorage, web3ProviderStorage } from '@extension/storage';
 import { getLogs, getPendingRequests, getConnectedSites, SW_STARTED_AT } from './providerLog';
+import { BROWSER_TOOLS, executeBrowserTool, isBrowserTool } from './browserTools';
 
 const TAG = ' | mcpBridge | ';
 const BRIDGE_URL = 'ws://localhost:1646/bex-bridge';
@@ -52,6 +53,62 @@ const ACCOUNT_CHAINS = [
   'cosmos',
   'osmosis',
   'ripple',
+];
+
+/**
+ * The tier-1 introspection catalog. It lives HERE, next to the code that
+ * implements it, rather than in the vault — the vault serves whatever
+ * bex_list_tools returns (see HANDOFF_vault_mcp_dumb_pipe.md). That keeps every
+ * future tool a one-repo change instead of a cross-repo one, which is the only
+ * reason the browser tools below could ship without touching the vault at all.
+ */
+const INTROSPECTION_TOOLS = [
+  {
+    name: 'bex_status',
+    description:
+      'KeepKey extension health: extension version, device/vault connection state, active EVM network, bridge status. Works even when the extension bridge is down (reports bridge: "down").',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'bex_accounts',
+    description:
+      'Per-chain accounts exactly as the extension returns them to dApps via request_accounts — raw shape preserved (string vs array), plus the underlying pubkey/xpub cache entries.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        chains: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Chains to query (e.g. ["ethereum","bitcoin","thorchain"]). Default: all supported.',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'bex_pending_requests',
+    description: 'The extension approval queue: requests waiting for user approval in the side panel.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'bex_connected_sites',
+    description: 'Origins that have made provider requests through the extension, with the chains each has touched.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'bex_logs',
+    description:
+      'Structured provider request/response log from the extension background (every injected request, its result or error code). Ring buffer, newest last. This is the wallet-traffic view a generic browser MCP cannot give you.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string', description: 'Regex filter over method/origin/error' },
+        since: { type: 'number', description: 'Only entries with timestamp >= this (ms epoch)' },
+        limit: { type: 'number', description: 'Max entries returned (default 100)' },
+      },
+      additionalProperties: false,
+    },
+  },
 ];
 
 export interface McpBridgeDeps {
@@ -180,6 +237,11 @@ function scheduleReconnect(): void {
 
 async function executeTool(tool: string, args: any): Promise<any> {
   if (!deps) throw new Error('bridge not initialized');
+
+  // The vault asks for the catalog on tools/list and serves it verbatim.
+  if (tool === 'bex_list_tools') return { tools: [...INTROSPECTION_TOOLS, ...BROWSER_TOOLS] };
+  if (isBrowserTool(tool)) return executeBrowserTool(tool, args);
+
   switch (tool) {
     case 'bex_status': {
       const state = deps.getKeepKeyState();

--- a/pages/content/src/agentDom.ts
+++ b/pages/content/src/agentDom.ts
@@ -1,0 +1,359 @@
+/**
+ * agentDom — the page-side half of the browser-driving MCP tools.
+ *
+ * The background (mcpBridge → browserTools.ts) sends BEX_AGENT_DOM messages here
+ * and we answer with a snapshot / click / type / read result.
+ *
+ * Design follows the convention Playwright MCP and Chrome DevTools MCP arrived at
+ * independently: expose an accessibility-shaped list of INTERACTIVE elements, each
+ * with an opaque `ref` handle minted here, and have the agent act on refs. The
+ * agent never invents a CSS selector and never clicks a pixel coordinate — both
+ * are the classic flake sources. Refs live in `refs` below and are re-minted on
+ * every snapshot; a stale ref fails loudly rather than hitting the wrong element.
+ *
+ * ponytail: this computes a role/name approximation from the DOM instead of asking
+ * Chrome for the real AX tree via chrome.debugger. Costs us nothing (no `debugger`
+ * permission, no "extension is debugging this browser" infobar, no conflict with a
+ * DevTools window) and sidesteps the ignored-node bloat that makes the real AX tree
+ * ~50% dead weight. Upgrade path if a page's roles come out wrong: add the
+ * `debugger` permission and swap snapshot() for Accessibility.getFullAXTree.
+ */
+
+const TAG = ' | agentDom | ';
+
+/** ref → element, re-minted per snapshot. Stale refs fail with stale_ref. */
+const refs = new Map<string, Element>();
+let refSeq = 0;
+
+// Elements a user can actually act on. Kept explicit rather than a broad
+// `[role]` sweep, which drags in every role="presentation" wrapper.
+const INTERACTIVE = [
+  'a[href]',
+  'button',
+  'input:not([type="hidden"])',
+  'select',
+  'textarea',
+  'summary',
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])',
+  '[role="button"]',
+  '[role="link"]',
+  '[role="checkbox"]',
+  '[role="radio"]',
+  '[role="tab"]',
+  '[role="switch"]',
+  '[role="menuitem"]',
+  '[role="option"]',
+  '[role="combobox"]',
+  '[role="textbox"]',
+  '[role="searchbox"]',
+  '[role="slider"]',
+].join(',');
+
+// Non-interactive elements worth keeping for orientation — without these a
+// snapshot is a pile of buttons with no indication of what page you're on.
+const CONTEXT = 'h1,h2,h3,h4,h5,h6,[role="heading"]';
+
+const INPUT_ROLES: Record<string, string> = {
+  checkbox: 'checkbox',
+  radio: 'radio',
+  button: 'button',
+  submit: 'button',
+  reset: 'button',
+  image: 'button',
+  range: 'slider',
+  file: 'file',
+  search: 'searchbox',
+};
+
+/**
+ * Walk element children AND open shadow roots. Web3 UI kits (web3modal's
+ * <w3m-modal>, most Lit-based connect flows) put their whole tree in shadow DOM,
+ * so a plain querySelectorAll returns nothing for exactly the dialogs an agent
+ * most needs to drive. Closed roots stay invisible — nothing we can do there.
+ */
+function deepQuery(root: ParentNode, selector: string, out: Element[] = []): Element[] {
+  for (const el of Array.from(root.querySelectorAll('*'))) {
+    if (el.matches(selector)) out.push(el);
+    const sr = (el as HTMLElement).shadowRoot;
+    if (sr) deepQuery(sr, selector, out);
+  }
+  return out;
+}
+
+function isVisible(el: Element): boolean {
+  const style = window.getComputedStyle(el);
+  if (style.visibility === 'hidden' || style.display === 'none' || style.opacity === '0') return false;
+  const rect = el.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) return false;
+  if (el.closest('[aria-hidden="true"]')) return false;
+  return true;
+}
+
+function roleOf(el: Element): string {
+  const explicit = el.getAttribute('role');
+  if (explicit) return explicit;
+  const tag = el.tagName.toLowerCase();
+  if (tag === 'a') return 'link';
+  if (tag === 'button' || tag === 'summary') return 'button';
+  if (tag === 'select') return 'combobox';
+  if (tag === 'textarea') return 'textbox';
+  if (tag === 'input') {
+    const type = ((el as HTMLInputElement).type || 'text').toLowerCase();
+    return INPUT_ROLES[type] ?? 'textbox';
+  }
+  if (/^h[1-6]$/.test(tag)) return 'heading';
+  if (el.hasAttribute('contenteditable')) return 'textbox';
+  return 'generic';
+}
+
+/**
+ * Accessible-name approximation, in roughly the precedence order the real
+ * accname spec uses. Not spec-complete (no aria-describedby fallback, no
+ * text-alternative recursion) — good enough to name a button.
+ */
+function nameOf(el: Element): string {
+  const aria = el.getAttribute('aria-label');
+  if (aria?.trim()) return aria.trim();
+
+  // Resolve id references against the element's own root, not ownerDocument:
+  // ids inside a shadow root are scoped to it, so ownerDocument would miss them
+  // entirely — or, worse, find an unrelated same-id element in the main
+  // document and mislabel the field.
+  const root = el.getRootNode() as Document | ShadowRoot;
+
+  const labelledBy = el.getAttribute('aria-labelledby');
+  if (labelledBy) {
+    const text = labelledBy
+      .split(/\s+/)
+      .map(id => root.getElementById?.(id)?.textContent ?? '')
+      .join(' ')
+      .trim();
+    if (text) return text;
+  }
+
+  if (el.id) {
+    const label = root.querySelector(`label[for="${CSS.escape(el.id)}"]`);
+    if (label?.textContent?.trim()) return label.textContent.trim();
+  }
+  const wrapping = el.closest('label');
+  if (wrapping?.textContent?.trim()) return wrapping.textContent.trim();
+
+  for (const attr of ['placeholder', 'alt', 'title', 'name']) {
+    const v = el.getAttribute(attr);
+    if (v?.trim()) return v.trim();
+  }
+
+  const text = (el as HTMLElement).innerText ?? el.textContent ?? '';
+  return text.trim();
+}
+
+const clip = (s: string, max = 120) => (s.length > max ? `${s.slice(0, max)}…` : s);
+
+interface SnapNode {
+  ref?: string;
+  role: string;
+  name: string;
+  value?: string;
+  disabled?: boolean;
+  checked?: boolean;
+  level?: number;
+}
+
+function snapshot(): { url: string; title: string; nodes: SnapNode[] } {
+  refs.clear();
+  refSeq = 0;
+
+  const found = deepQuery(document, `${INTERACTIVE},${CONTEXT}`);
+  const nodes: SnapNode[] = [];
+
+  for (const el of found) {
+    if (!isVisible(el)) continue;
+    const role = roleOf(el);
+    const name = clip(nameOf(el).replace(/\s+/g, ' '));
+    const isContext = el.matches(CONTEXT);
+
+    // An unnamed heading is noise; an unnamed BUTTON is still clickable and the
+    // agent may need it (icon-only close buttons are the common case), so it
+    // stays with an empty name.
+    if (isContext && !name) continue;
+
+    const node: SnapNode = { role, name };
+
+    if (isContext) {
+      const lvl = Number(el.getAttribute('aria-level') ?? el.tagName.slice(1));
+      if (Number.isFinite(lvl)) node.level = lvl;
+    } else {
+      const ref = `e${++refSeq}`;
+      refs.set(ref, el);
+      node.ref = ref;
+      const input = el as HTMLInputElement;
+      if (input.value != null && typeof input.value === 'string' && input.value) node.value = clip(input.value, 60);
+      if (isDisabled(el)) node.disabled = true;
+      // aria-checked first: dApp toggles are usually a styled div with a role,
+      // not a real <input>, so .checked would silently miss them.
+      const ariaChecked = el.getAttribute('aria-checked');
+      if (ariaChecked === 'true' || ariaChecked === 'false') node.checked = ariaChecked === 'true';
+      else if (typeof input.checked === 'boolean' && (role === 'checkbox' || role === 'radio'))
+        node.checked = input.checked;
+    }
+
+    nodes.push(node);
+  }
+
+  return { url: location.href, title: document.title, nodes };
+}
+
+function resolve(ref: string): Element {
+  const el = refs.get(ref);
+  if (!el) {
+    throw Object.assign(new Error(`ref ${ref} is not in the current snapshot — take a fresh bex_snapshot`), {
+      code: 'stale_ref',
+    });
+  }
+  if (!el.isConnected) {
+    throw Object.assign(new Error(`ref ${ref} has been removed from the page — take a fresh bex_snapshot`), {
+      code: 'stale_ref',
+    });
+  }
+  return el;
+}
+
+/**
+ * Dispatch a full pointer sequence, not just el.click(). Radix, Headless UI and
+ * most modern dialog kits (i.e. every wallet-connect modal worth testing) listen
+ * on pointerdown/mousedown and never see a bare click().
+ *
+ * ponytail: these events are isTrusted=false. React/Vue/Radix don't care, so
+ * this covers the dApp surface we test. A site that explicitly gates on
+ * isTrusted needs the `debugger` permission and Input.dispatchMouseEvent.
+ */
+function isDisabled(el: Element): boolean {
+  return (el as HTMLButtonElement).disabled === true || el.getAttribute('aria-disabled') === 'true';
+}
+
+function fireClick(el: Element): void {
+  // dispatchEvent bypasses the disabled check that stops a native click, so
+  // without this guard an agent could fire a handler no user could reach — and
+  // "the Swap button is disabled until you enter an amount" is exactly the kind
+  // of gating this tool exists to verify. Refusing keeps agent runs honest.
+  if (isDisabled(el)) {
+    throw Object.assign(new Error(`element is disabled — a user could not click it`), { code: 'element_disabled' });
+  }
+  el.scrollIntoView({ block: 'center', inline: 'center' });
+  const rect = el.getBoundingClientRect();
+  const base = {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    view: window,
+    clientX: rect.left + rect.width / 2,
+    clientY: rect.top + rect.height / 2,
+  };
+  const pointer = { ...base, pointerId: 1, isPrimary: true, pointerType: 'mouse' };
+  el.dispatchEvent(new PointerEvent('pointerdown', { ...pointer, button: 0, buttons: 1 }));
+  el.dispatchEvent(new MouseEvent('mousedown', { ...base, button: 0, buttons: 1 }));
+  (el as HTMLElement).focus?.();
+  el.dispatchEvent(new PointerEvent('pointerup', { ...pointer, button: 0, buttons: 0 }));
+  el.dispatchEvent(new MouseEvent('mouseup', { ...base, button: 0, buttons: 0 }));
+  el.dispatchEvent(new MouseEvent('click', { ...base, button: 0, buttons: 0, detail: 1 }));
+}
+
+/**
+ * Set a value the way a user would, as far as a framework can tell. Assigning
+ * .value directly is invisible to React — it tracks the last value it wrote on
+ * the node and dedupes, so the input event looks like a no-op. Going through the
+ * prototype's native setter defeats that tracker. Well-worn trick; not ours.
+ */
+function setValue(el: Element, text: string): void {
+  if (isDisabled(el) || (el as HTMLInputElement).readOnly) {
+    throw Object.assign(new Error('field is disabled or read-only — a user could not type here'), {
+      code: 'element_disabled',
+    });
+  }
+  (el as HTMLElement).focus?.();
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+    if (setter) setter.call(el, text);
+    else el.value = text;
+  } else if (el.hasAttribute('contenteditable')) {
+    (el as HTMLElement).innerText = text;
+  } else {
+    throw Object.assign(new Error(`element is a ${roleOf(el)}, not a text field`), { code: 'not_editable' });
+  }
+  el.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+  el.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+}
+
+function readPage(selector: string | undefined, maxChars: number): { text: string; truncated: boolean } {
+  const root = selector ? document.querySelector(selector) : (document.querySelector('main') ?? document.body);
+  if (!root) throw Object.assign(new Error(`no element matches ${selector}`), { code: 'not_found' });
+  const full = ((root as HTMLElement).innerText ?? root.textContent ?? '').replace(/\n{3,}/g, '\n\n').trim();
+  return { text: full.slice(0, maxChars), truncated: full.length > maxChars };
+}
+
+async function handle(msg: any): Promise<any> {
+  switch (msg.op) {
+    case 'snapshot':
+      return snapshot();
+
+    case 'click':
+      fireClick(resolve(msg.ref));
+      return { clicked: msg.ref };
+
+    case 'type': {
+      const el = resolve(msg.ref);
+      setValue(el, String(msg.text ?? ''));
+      if (msg.submit) {
+        const key = { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true, composed: true };
+        const notCancelled = el.dispatchEvent(new KeyboardEvent('keydown', { ...key, cancelable: true }));
+        el.dispatchEvent(new KeyboardEvent('keyup', key));
+        // Mirror the browser's own implicit-submission rule: submit the form
+        // only if nothing cancelled the keydown. An app that handles Enter
+        // itself (and preventDefaults) would otherwise fire twice.
+        if (notCancelled) (el as HTMLInputElement).form?.requestSubmit?.();
+      }
+      return { typed: msg.ref, submitted: !!msg.submit };
+    }
+
+    case 'select': {
+      const el = resolve(msg.ref) as HTMLSelectElement;
+      if (!(el instanceof HTMLSelectElement)) {
+        throw Object.assign(new Error('element is not a <select>'), { code: 'not_editable' });
+      }
+      el.value = String(msg.value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+      return { selected: msg.value };
+    }
+
+    case 'read':
+      return readPage(msg.selector, Number(msg.maxChars) || 10_000);
+
+    case 'find': {
+      // Search the snapshot page-side and return only the hits, so the agent can
+      // locate one button without pulling the whole tree into context.
+      const snap = snapshot();
+      const needle = String(msg.text ?? '');
+      const re = msg.regex ? new RegExp(needle, 'i') : null;
+      const hit = (n: SnapNode) => (re ? re.test(n.name) : n.name.toLowerCase().includes(needle.toLowerCase()));
+      return { url: snap.url, title: snap.title, nodes: snap.nodes.filter(hit) };
+    }
+
+    default:
+      throw Object.assign(new Error(`unknown dom op: ${msg.op}`), { code: 'unknown_op' });
+  }
+}
+
+export function installAgentDom(): void {
+  chrome.runtime.onMessage.addListener((msg: any, _sender, sendResponse) => {
+    if (msg?.type !== 'BEX_AGENT_DOM') return;
+    handle(msg)
+      .then(data => sendResponse({ ok: true, data }))
+      .catch(e => sendResponse({ ok: false, code: e?.code ?? 'dom_error', message: e?.message || String(e) }));
+    return true; // async sendResponse
+  });
+  console.log(TAG, 'agent DOM listener installed');
+}

--- a/pages/content/src/index.ts
+++ b/pages/content/src/index.ts
@@ -1,6 +1,7 @@
 // Enhanced content script with injection verification and security improvements
 
 import type { WalletMessage } from '../../../chrome-extension/src/injected/types';
+import { installAgentDom } from './agentDom';
 
 const INJECTION_TIMEOUT = 5000; // 5 seconds
 const MAX_INJECTION_RETRIES = 3;
@@ -432,3 +433,6 @@ chrome.runtime.onMessage.addListener((message: any) => {
     window.postMessage({ type: 'CHAIN_CHANGED', provider: message.provider }, '*');
   }
 });
+
+// Browser-driving MCP tools (bex_snapshot / bex_click / …) run their DOM work here.
+installAgentDom();

--- a/scripts/fixture-agent-page.html
+++ b/scripts/fixture-agent-page.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+  <head>
+    <title>BEX agent fixture</title>
+  </head>
+  <body>
+    <!--
+      Fixture for scripts/test-mcp-bridge.mjs. Deliberately shaped like the dApp
+      flows the browser tools exist to drive:
+        - a Connect button whose click is only observable via rendered text
+        - an amount field that gates a Swap button (framework-style reactive
+          disable — proves bex_type fires real input events, not just .value=)
+        - a button inside an open shadow root (web3modal and every Lit-based
+          connect modal live in shadow DOM; a snapshot that can't see in there is
+          useless for exactly the dialogs that matter)
+    -->
+    <main>
+      <h1>Agent Fixture</h1>
+      <button id="connect">Connect Wallet</button>
+      <label for="amt">You pay</label>
+      <input id="amt" value="0" />
+      <button id="swap" disabled>Swap</button>
+      <p id="out">idle</p>
+      <shadow-panel></shadow-panel>
+    </main>
+
+    <script>
+      const out = document.getElementById('out');
+      const amt = document.getElementById('amt');
+      const swap = document.getElementById('swap');
+
+      document.getElementById('connect').onclick = () => {
+        out.textContent = 'connected';
+      };
+      amt.addEventListener('input', () => {
+        swap.disabled = !(Number(amt.value) > 0);
+      });
+      swap.onclick = () => {
+        out.textContent = 'swapped ' + amt.value;
+      };
+
+      customElements.define(
+        'shadow-panel',
+        class extends HTMLElement {
+          connectedCallback() {
+            const root = this.attachShadow({ mode: 'open' });
+            root.innerHTML = '<button id="deep">Deep Shadow Button</button>';
+            root.getElementById('deep').onclick = () => {
+              out.textContent = 'shadow clicked';
+            };
+          }
+        },
+      );
+    </script>
+  </body>
+</html>

--- a/scripts/test-browser-tools.mjs
+++ b/scripts/test-browser-tools.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Exit test for the browser-driving MCP tools (bex_snapshot/click/type/…).
+ *
+ * Serves its own fixture page on an ephemeral port and drives it through the
+ * real stack: this script → vault POST /mcp → WS bridge → BEX background →
+ * content script → DOM. Nothing is mocked; a pass means an agent can drive a
+ * page in the user's Chrome for real.
+ *
+ * Preconditions (human, one-time):
+ *   1. vault running on :1646, PATCHED per HANDOFF_vault_mcp_dumb_pipe.md
+ *      (unpatched → tools/list omits the browser tools and this fails at step 1)
+ *   2. extension loaded from dist/, options-page "Agent mode" toggle ON
+ *
+ *   KEEPKEY_API_KEY=<pairing key> node scripts/test-browser-tools.mjs
+ *
+ * Opens and closes one tab in your Chrome. Exits 0 on pass, 1 on failure,
+ * 2 if the bridge is down (Agent mode off / extension not loaded).
+ */
+
+import { createServer } from 'node:http';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const MCP_URL = 'http://localhost:1646/mcp';
+const BROWSER_TOOLS = [
+  'bex_tabs',
+  'bex_navigate',
+  'bex_snapshot',
+  'bex_find',
+  'bex_click',
+  'bex_type',
+  'bex_select',
+  'bex_read_page',
+  'bex_screenshot',
+];
+
+const API_KEY = process.env.KEEPKEY_API_KEY;
+if (!API_KEY) {
+  console.error('KEEPKEY_API_KEY is required (the vault bearer-authenticates /mcp).');
+  console.error("Get the extension's key from the background console: chrome.storage.local.get('keepkey-api-key')");
+  process.exit(1);
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = readFileSync(join(here, 'fixture-agent-page.html'), 'utf8');
+
+let nextId = 1;
+async function rpc(method, params) {
+  const res = await fetch(MCP_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${API_KEY}` },
+    body: JSON.stringify({ jsonrpc: '2.0', id: nextId++, method, ...(params ? { params } : {}) }),
+  });
+  if (res.status === 401) throw new Error(`${method}: HTTP 401 — KEEPKEY_API_KEY is not a valid vault pairing key`);
+  if (!res.ok) throw new Error(`${method}: HTTP ${res.status}`);
+  const body = await res.json();
+  if (body.error) throw new Error(`${method}: rpc error ${body.error.code} ${body.error.message}`);
+  return body.result;
+}
+
+/** Call a tool; throw on isError so a failed tool fails the test loudly. */
+async function tool(name, args = {}) {
+  const res = await rpc('tools/call', { name, arguments: args });
+  if (res.isError) throw new Error(`${name} failed: ${res.content?.[0]?.text ?? 'unknown'}`);
+  return res;
+}
+const toolText = async (name, args) => (await tool(name, args)).content[0].text;
+const toolJson = async (name, args) => JSON.parse(await toolText(name, args));
+
+let failures = 0;
+function assert(cond, msg) {
+  if (cond) {
+    console.log(`ok: ${msg}`);
+  } else {
+    console.error(`FAIL: ${msg}`);
+    failures++;
+  }
+}
+
+/** Pull the ref out of a snapshot line like: - button "Swap" [ref=e3] [disabled] */
+function refFor(snapshot, name) {
+  const line = snapshot.split('\n').find(l => l.includes(`"${name}"`));
+  return line?.match(/\[ref=(e\d+)\]/)?.[1];
+}
+const lineFor = (snapshot, name) => snapshot.split('\n').find(l => l.includes(`"${name}"`)) ?? '';
+
+const server = createServer((_req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/html' });
+  res.end(fixture);
+});
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+const url = `http://127.0.0.1:${server.address().port}/`;
+console.log(`fixture served at ${url}\n`);
+
+let tabId;
+try {
+  // 1. The catalog must include the browser tools — i.e. the vault is serving
+  //    the BEX's catalog, not its own static list.
+  const { tools } = await rpc('tools/list');
+  const names = tools.map(t => t.name);
+  if (!names.includes('bex_snapshot')) {
+    console.error('FAIL: tools/list has no browser tools — is the vault patched per HANDOFF_vault_mcp_dumb_pipe.md?');
+    console.error(`      tools/list returned: ${names.join(', ')}`);
+    process.exit(1);
+  }
+  for (const t of BROWSER_TOOLS) assert(names.includes(t), `tools/list includes ${t}`);
+
+  const status = JSON.parse((await rpc('tools/call', { name: 'bex_status', arguments: {} })).content[0].text);
+  if (status.bridge !== 'up') {
+    console.log('\nbridge is DOWN — load the extension and turn on Agent mode in its options page, then re-run');
+    process.exit(2);
+  }
+
+  // 2. Open the fixture.
+  const created = await toolJson('bex_tabs', { action: 'create', url });
+  tabId = created.tabId;
+  assert(typeof tabId === 'number', `bex_tabs create opened tab ${tabId}`);
+
+  // 3. Snapshot: refs minted, roles/names right, disabled state visible, and
+  //    the shadow-root button surfaced (deepQuery works).
+  const snap = await toolText('bex_snapshot', { tabId });
+  console.log(`\n--- bex_snapshot ---\n${snap}\n`);
+  assert(/heading "Agent Fixture"/.test(snap), 'snapshot names the h1 heading');
+  assert(refFor(snap, 'Connect Wallet'), 'snapshot mints a ref for the Connect Wallet button');
+  assert(/textbox "You pay"/.test(snap), 'snapshot resolves the input label to an accessible name');
+  assert(/\[disabled\]/.test(lineFor(snap, 'Swap')), 'snapshot reports Swap as disabled');
+  assert(refFor(snap, 'Deep Shadow Button'), 'snapshot pierces the open shadow root');
+
+  // 4. A disabled button must REFUSE the click rather than fire its handler —
+  //    otherwise an agent gets a pass on gating a real user could never defeat.
+  const early = await rpc('tools/call', {
+    name: 'bex_click',
+    arguments: { tabId, ref: refFor(snap, 'Swap'), element: 'Swap button (still disabled)' },
+  });
+  assert(early.isError && /element_disabled/.test(early.content[0].text), 'clicking a disabled button is refused');
+  assert(!(await toolText('bex_read_page', { tabId })).includes('swapped'), 'the refused click did not fire the handler');
+
+  // 5. Click → assert via rendered text, not pixels.
+  await tool('bex_click', { tabId, ref: refFor(snap, 'Connect Wallet'), element: 'Connect Wallet button' });
+  assert((await toolText('bex_read_page', { tabId })).includes('connected'), 'bex_click fired the Connect handler');
+
+  // 6. Type → the fixture's input listener must fire and un-disable Swap. This
+  //    is the real assertion on setValue()'s native-setter path: a plain
+  //    `el.value = x` would leave Swap disabled here.
+  const amountRef = refFor(snap, 'You pay');
+  await tool('bex_type', { tabId, ref: amountRef, element: 'You pay amount field', text: '1.5' });
+  const afterType = await toolText('bex_snapshot', { tabId });
+  assert(!/\[disabled\]/.test(lineFor(afterType, 'Swap')), 'bex_type fired input events — Swap became enabled');
+  assert(/value="1\.5"/.test(lineFor(afterType, 'You pay')), 'snapshot reflects the typed value');
+
+  // 7. bex_find returns only hits, with usable refs.
+  const found = await toolText('bex_find', { tabId, text: 'swap' });
+  assert(refFor(found, 'Swap'), 'bex_find locates Swap and returns its ref');
+  assert(!found.includes('Connect Wallet'), 'bex_find returns only matches, not the whole page');
+
+  await tool('bex_click', { tabId, ref: refFor(afterType, 'Swap'), element: 'Swap button' });
+  assert((await toolText('bex_read_page', { tabId })).includes('swapped 1.5'), 'the full type→click flow works');
+
+  // 8. Stale refs must fail loudly rather than hit the wrong element.
+  const stale = await rpc('tools/call', { name: 'bex_click', arguments: { tabId, ref: 'e9999', element: 'nonexistent' } });
+  assert(stale.isError && /stale_ref/.test(stale.content[0].text), 'a stale ref returns a structured stale_ref error');
+
+  // 9. Screenshot comes back as an MCP image block (proves the vault passes
+  //    content through) and is downscaled enough to be affordable.
+  const shot = (await tool('bex_screenshot', { tabId })).content[0];
+  assert(shot.type === 'image' && shot.mimeType === 'image/jpeg', 'bex_screenshot returns an image content block');
+  const kb = Math.round((shot.data.length * 0.75) / 1024);
+  assert(kb > 0 && kb < 300, `screenshot is ${kb}KB (downscaled, not a raw retina capture)`);
+} finally {
+  if (tabId != null) await tool('bex_tabs', { action: 'close', tabId }).catch(() => {});
+  server.close();
+}
+
+if (failures) {
+  console.error(`\n${failures} assertion(s) FAILED`);
+  process.exit(1);
+}
+console.log('\nBrowser-tools exit test PASSED');


### PR DESCRIPTION
Expands the MCP agent bridge (#109) from five read-only introspection tools to a full browser-driving surface, so Claude Code and other coding agents can drive a dApp end-to-end against the real wallet.

## Why not just use Playwright MCP

Because it launches a clean browser with no wallet in it. The thing this extension uniquely has is that it's *already in the user's Chrome, holding the wallet* — so an agent can click a dApp's Connect button, watch the approval land in `bex_pending_requests`, and read the provider traffic out of `bex_logs`, all in one session. Generic browser MCPs can do the clicking; none can do the wallet half. That overlap is the only reason this is worth building.

(It's also not optional: Playwright/Puppeteer can't run in-extension at all. The background bundles to one IIFE with no Node builtins, so `chrome.debugger` and content scripts are the only paths available.)

## Tool surface — 9 new tools

`bex_tabs` · `bex_navigate` · `bex_snapshot` · `bex_find` · `bex_click` · `bex_type` · `bex_select` · `bex_read_page` · `bex_screenshot`

Design follows the convention Microsoft (Playwright MCP) and Google (Chrome DevTools MCP) arrived at **independently**: an a11y-shaped snapshot of interactive elements, each with an opaque `[ref=eN]` handle minted page-side, and the agent acts on refs.

```
page https://app.example.com/swap — "Swap"
- heading "Swap" [level=1]
- button "Connect Wallet" [ref=e1]
- textbox "You pay" [ref=e2] value="0"
- button "Swap" [ref=e3] [disabled]
```

The agent never invents a CSS selector (the Puppeteer-MCP anti-pattern that made models guess `.btn-primary > span` and retry) and never clicks a coordinate. Screenshots are for visual verification only and say so in their own description.

## No internal LLM — deliberately

The caller is already a frontier model. Putting a weaker one in the middle to pre-digest the page (the Stagehand/browser-use model) would add latency and cost per step, inject nondeterminism into a layer that should be a deterministic effector, and cap accuracy at the weaker model's. Rule-based pruning is auditable; a model's summary of a page the caller never saw is not.

Worth knowing: **Pioneer already ships an OpenAI-compatible Venice proxy** — `@pioneer-platform/pioneer-inference`, live at `/v1/chat/completions`. If we want an inference product, that's where it goes, not in here.

## Cost: zero new permissions, zero new dependencies

`<all_urls>` and `tabs` are already granted (`manifest.js:39-40`) and the content script is already at `document_start` on every http/https page. No `debugger` permission — so no "extension is debugging this browser" infobar, no conflict with an open DevTools window, and no scary install-time prompt on a **wallet** extension. Roles/names are computed from the DOM instead, which also sidesteps the ignored-node bloat that makes the real AX tree ~50% dead weight ([chrome-devtools-mcp#635](https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/635), closed as wontfix).

## Details worth reviewing

- **Shadow DOM is pierced.** web3modal and every Lit-based connect modal live in a shadow root — a snapshot that can't see in there is blind to exactly the dialogs that matter.
- **Clicks fire a full pointer sequence.** Radix/Headless UI listen on `pointerdown` and never see a bare `.click()`.
- **Typing goes through the prototype's native value setter**, defeating React's value tracker — otherwise the `input` event looks like a no-op and reactive gating never updates.
- **Disabled elements refuse the click.** `dispatchEvent` bypasses the check that stops a native click, so without the guard an agent could fire a handler no user could reach and pass a test on gating it never defeated. The exit test asserts this.
- **Screenshots downscale to 1024px wide.** `captureVisibleTab` captures at devicePixelRatio and Claude bills images by *pixels*, so retina would otherwise cost 4x for no added legibility.

## Blocked on one vault change

The vault hardcodes the tool catalog (`mcp.ts:38`) and wraps every result as `{type:'text'}` (`:158`), so as-is `tools/list` won't mention these and screenshots have nowhere to put a JPEG. **`HANDOFF_vault_mcp_dumb_pipe.md`** specs the fix: have `tools/list` proxy to the new `bex_list_tools` and pass content blocks through. ~20 lines, once — after which the extension owns its whole tool surface and every future tool is a one-repo change.

**This PR is inert until that lands.** Per the no-cross-repo-vault rule it's a handoff doc, not a PR in the vault tree.

## Testing

`make test-mcp-browser` serves its own fixture and drives it through the real stack (script → vault `/mcp` → WS bridge → background → content script → DOM). Nothing mocked. Asserts refs, shadow-root piercing, disabled-click refusal, the input-event path, stale-ref errors, and image content blocks.

Not yet run end-to-end — it needs the vault patch above plus Agent mode on. `make type-check`, `make lint` (0 errors) and `make test` (111 passing) are green, and both bundles build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)