### PR TITLE
feat(mcp): Enable MCP toggle + copy agent config in side-panel Settings

### DIFF
--- a/pages/side-panel/src/components/Settings.tsx
+++ b/pages/side-panel/src/components/Settings.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { VStack, HStack, Avatar, Text, Switch, Link, Button, Image, Box, useToast } from '@chakra-ui/react';
+import { VStack, HStack, Avatar, Text, Switch, Link, Button, Image, Box, Code, useToast } from '@chakra-ui/react';
+import { CopyIcon } from '@chakra-ui/icons';
 import {
   maskingSettingsStorage,
   requestStorage,
@@ -14,6 +15,7 @@ import {
   customEvmNetworksStorage,
   ethAccountsStorage,
   testnetSettingsStorage,
+  agentModeStorage,
 } from '@extension/storage';
 
 const TAG = ' | Settings | ';
@@ -27,6 +29,7 @@ const Settings = () => {
     enablePhantomMasking: false,
   });
   const [showTestnets, setShowTestnets] = useState(false);
+  const [agentMode, setAgentMode] = useState(false);
 
   // Fetch initial masking settings from storage
   useEffect(() => {
@@ -45,10 +48,50 @@ const Settings = () => {
 
       const testnetSetting = await testnetSettingsStorage.getShowTestnets();
       setShowTestnets(testnetSetting);
+
+      setAgentMode(await agentModeStorage.get());
     };
 
     loadSettings();
   }, []);
+
+  const toggleAgentMode = async () => {
+    const newValue = !agentMode;
+    setAgentMode(newValue); // optimistic
+    await agentModeStorage.set(newValue);
+    toast({
+      title: newValue ? 'MCP enabled' : 'MCP disabled',
+      description: newValue
+        ? 'Agents can now read wallet state over the local MCP bridge.'
+        : 'The MCP bridge is disconnected; agents can no longer read wallet state.',
+      status: newValue ? 'success' : 'info',
+      duration: 4000,
+      isClosable: true,
+    });
+  };
+
+  const copyMcpConfig = async () => {
+    const apiKey = await keepKeyApiKeyStorage.getApiKey();
+    if (!apiKey) {
+      toast({
+        title: 'Not paired yet',
+        description: 'Pair the extension with the KeepKey vault first, then copy the agent config.',
+        status: 'warning',
+        duration: 5000,
+        isClosable: true,
+      });
+      return;
+    }
+    const cmd = `claude mcp add --transport http keepkey http://localhost:1646/mcp --header "Authorization: Bearer ${apiKey}"`;
+    await navigator.clipboard.writeText(cmd);
+    toast({
+      title: 'Agent config copied',
+      description: 'Contains your local pairing key — treat it like a secret. Paste it into your agent terminal.',
+      status: 'success',
+      duration: 5000,
+      isClosable: true,
+    });
+  };
 
   const toggleTestnets = async () => {
     const newValue = !showTestnets;
@@ -228,6 +271,33 @@ const Settings = () => {
         </HStack>
         <Text fontSize="xs" color="whiteAlpha.700" mt={-2} mb={2}>
           Adds Ethereum Sepolia, Base Sepolia, and Solana Devnet with default public RPCs. Turning off removes them.
+        </Text>
+
+        <Text fontSize="md" fontWeight="bold">
+          Agent Mode (MCP)
+        </Text>
+
+        {/* Enable MCP bridge */}
+        <HStack w="100%" justifyContent="space-between">
+          <Text>Enable MCP</Text>
+          <Switch size="md" isChecked={agentMode} onChange={toggleAgentMode} />
+        </HStack>
+        <Text fontSize="xs" color="kk.dim" mt={-2} mb={2}>
+          Lets an AI agent (Claude Code, Claude Desktop, …) read wallet state over a local Model Context Protocol bridge
+          — device status, accounts, pending requests, connected sites, and logs. Read-only: agents can never move
+          funds; every signature still requires the physical device button. Off by default.{' '}
+          <Link href="https://docs.keepkey.com/docs/bex/mcp" isExternal textDecoration="underline">
+            Learn more
+          </Link>
+        </Text>
+
+        {/* Copy agent connection config */}
+        <Button leftIcon={<CopyIcon />} variant="outline" size="sm" w="100%" onClick={copyMcpConfig}>
+          Copy agent config
+        </Button>
+        <Text fontSize="xs" color="kk.dim" mt={1} mb={2}>
+          Copies a <Code fontSize="xs">claude mcp add</Code> command with your local pairing key. It contains a secret —
+          paste it only into your own agent, never share it. The agent connects once you enable MCP above.
         </Text>
 
         <Text fontSize="md" fontWeight="bold">


### PR DESCRIPTION
## What

Adds an **Agent Mode (MCP)** section to the side-panel Settings:

- **Enable MCP** switch — bound to the existing `agentModeStorage` (`keepkey-agent-mode`, default OFF), which the background bridge already gates on. No new gating logic; the toggle the bridge subscribes to simply had no UI where users actually look.
- **Copy agent config** — copies a ready-to-paste `claude mcp add --transport http` command with the vault pairing key embedded, and toasts a warning that it contains a secret.

An Agent-mode toggle already existed on the **options page**, but not in the side-panel Settings that users actually open.

## Why the config embeds the pairing key

The deployed vault **bearer-authenticates `/mcp`** — verified live:

```
POST /mcp, no Authorization  -> 401 {"error":"No bearer token — pair first via POST /auth/pair"}
POST /mcp, bogus bearer      -> 401
POST /mcp, with Origin       -> 403  (loopback-only; browsers rejected)
```

So there is no tokenless path. Note `EPIC_mcp_agent_bridge.md` claims `/mcp` is "loopback-only, no bearer key" — that is **stale** and does not match the deployed vault.

The key is loopback-scoped but still wallet-sensitive, hence the warning toast. If the extension isn't paired yet, the button says so instead of copying an empty key.

CLI syntax verified against `claude mcp add --help`.

## Docs

Companion page documenting all of this (setup, tool surface, security model, troubleshooting) is up at BitHighlander/keepkey-docs-v8#7 → `/docs/bex/mcp`, which the "Learn more" link here points at.

## Test

`make type-check` 15/15, `make build` 9/9.

Manual: Settings → Agent Mode (MCP) → toggle on/off (persists, background bridge connects/disconnects) → Copy agent config → paste into a terminal → agent connects and `bex_status` answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)