### PR TITLE
fix(mcp): scope the read-only claim to today's tools; guard clipboard copy

### DIFF
--- a/pages/side-panel/src/components/Settings.tsx
+++ b/pages/side-panel/src/components/Settings.tsx
@@ -83,7 +83,20 @@ const Settings = () => {
       return;
     }
     const cmd = `claude mcp add --transport http keepkey http://localhost:1646/mcp --header "Authorization: Bearer ${apiKey}"`;
-    await navigator.clipboard.writeText(cmd);
+    // The getApiKey() await above can outlive transient user activation, and the
+    // side panel loses document focus easily — either makes writeText reject.
+    try {
+      await navigator.clipboard.writeText(cmd);
+    } catch {
+      toast({
+        title: 'Copy failed',
+        description: 'Clipboard access was blocked. Click the side panel to focus it, then try again.',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+      return;
+    }
     toast({
       title: 'Agent config copied',
       description: 'Contains your local pairing key — treat it like a secret. Paste it into your agent terminal.',
@@ -284,8 +297,9 @@ const Settings = () => {
         </HStack>
         <Text fontSize="xs" color="kk.dim" mt={-2} mb={2}>
           Lets an AI agent (Claude Code, Claude Desktop, …) read wallet state over a local Model Context Protocol bridge
-          — device status, accounts, pending requests, connected sites, and logs. Read-only: agents can never move
-          funds; every signature still requires the physical device button. Off by default.{' '}
+          — device status, accounts, pending requests, connected sites, and logs. Today's tools only read. The lasting
+          guarantee is not that list, which will grow, but the device: no agent can sign, because every signature still
+          requires the physical button. Off by default.{' '}
           <Link href="https://docs.keepkey.com/docs/bex/mcp" isExternal textDecoration="underline">
             Learn more
           </Link>


### PR DESCRIPTION
Follow-up to #113, which merged before this review fix landed on the branch.

## The claim

#113 shipped this in the Agent Mode blurb:

> Read-only: agents can never move funds; every signature still requires the physical device button.

**Read-only is true today** — the vault's `TOOLS` (`src/bun/mcp.ts:38`) advertises exactly the five introspection tools, and `TOOL_NAMES.has(name)` (:155) rejects everything else with `-32602 unknown tool`. The extension implements `bex_click`/`bex_navigate`/`bex_type`, but the vault is the only path an agent has and won't route them.

The problem is that it's a fact about **this version**, not a product promise. The tool list is meant to grow; the sentence quietly becomes false the day browser-driving lands, and it's the sentence someone quotes back after an incident. The docs page already takes the correct stance:

> The safety promise is the device confirmation, not "the tools are read-only". Read-only describes today's surface and nothing more.

So this reframes onto the invariant that doesn't move — the device button — while still saying plainly that today's tools only read.

## Clipboard guard

`copyMcpConfig` awaits `getApiKey()` before `clipboard.writeText`. Every other copy site in the side panel (`Receive.tsx`, `AssetDetail.tsx`, `AccountDropdown.tsx`) calls `writeText` synchronously inside the click handler; this is the one call that can land outside transient activation, or with the side panel unfocused. `writeText` then rejects, the success toast never fires, and the user gets silence plus an unhandled rejection. Now toasts the failure with a recovery hint.

No `clipboardWrite` in the manifest — fine today because of activation, worth knowing if that await ever slows.

## Test

`make type-check` 15/15, `make build` 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)