### PR TITLE
refactor(broadcast): finish broadcastViaPioneer migration (10 chain handlers)

### DIFF
--- a/chrome-extension/src/background/chains/bitcoinCashHandler.ts
+++ b/chrome-extension/src/background/chains/bitcoinCashHandler.ts
@@ -4,7 +4,7 @@ import { Chain, ChainToNetworkId, shortListSymbolToCaip, caipToNetworkId } from 
 import * as wallet from '../wallet';
 import { utxoAccountFromPubkeyRow } from '../utxoDerive';
 import { createProviderRpcError } from '../utils';
-import { fetchJsonWithTimeout } from '../fetchUtils';
+import { fetchJsonWithTimeout, broadcastViaPioneer } from '../fetchUtils';
 
 const TAG = ' | bitcoinCashHandler | ';
 
@@ -101,17 +101,7 @@ export const handleBitcoinCashRequest = async (
         response.signedTx = signedTx;
         await requestStorage.updateEventById(requestInfo.id, response);
 
-        let txHash: any = await fetchJsonWithTimeout<any>(
-          'https://api.keepkey.info/api/v1/broadcastTx',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ caip, signedTx: signedTx.serializedTx || signedTx }),
-          },
-          { timeoutMs: 15000, retries: 1 },
-        );
-        if (txHash.txHash) txHash = txHash.txHash;
-        if (txHash.txid) txHash = txHash.txid;
+        const txHash: any = await broadcastViaPioneer(caip, signedTx.serializedTx || signedTx);
         response.txid = txHash;
         await requestStorage.updateEventById(requestInfo.id, response);
         chrome.runtime.sendMessage({

--- a/chrome-extension/src/background/chains/bitcoinHandler.ts
+++ b/chrome-extension/src/background/chains/bitcoinHandler.ts
@@ -4,7 +4,7 @@ import { Chain, ChainToNetworkId, shortListSymbolToCaip, caipToNetworkId } from 
 import * as wallet from '../wallet';
 import { utxoAccountFromPubkeyRow } from '../utxoDerive';
 import { createProviderRpcError } from '../utils';
-import { fetchJsonWithTimeout } from '../fetchUtils';
+import { fetchJsonWithTimeout, broadcastViaPioneer } from '../fetchUtils';
 
 const TAG = ' | bitcoinHandler | ';
 
@@ -135,17 +135,7 @@ export const handleBitcoinRequest = async (
           // a transient Pioneer hiccup (e.g. node failover) would either
           // hang the dApp or surface as a malformed JSON error from the
           // raw `await response.json()` below.
-          let txHash: any = await fetchJsonWithTimeout<any>(
-            'https://api.keepkey.info/api/v1/broadcastTx',
-            {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ caip, signedTx: signedTx.serializedTx || signedTx }),
-            },
-            { timeoutMs: 15000, retries: 1 },
-          );
-          if (txHash.txHash) txHash = txHash.txHash;
-          if (txHash.txid) txHash = txHash.txid;
+          const txHash: any = await broadcastViaPioneer(caip, signedTx.serializedTx || signedTx);
 
           response.txid = txHash;
           await requestStorage.updateEventById(requestInfo.id, response);

--- a/chrome-extension/src/background/chains/cosmosHandler.ts
+++ b/chrome-extension/src/background/chains/cosmosHandler.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Chain, ChainToNetworkId, shortListSymbolToCaip, caipToNetworkId } from '../chainConfig';
 import * as wallet from '../wallet';
 import { createProviderRpcError } from '../utils';
-import { fetchJsonWithTimeout } from '../fetchUtils';
+import { fetchJsonWithTimeout, broadcastViaPioneer } from '../fetchUtils';
 
 const TAG = ' | cosmosHandler | ';
 
@@ -95,17 +95,7 @@ export const handleCosmosRequest = async (
         response.signedTx = signedTx;
         await requestStorage.updateEventById(requestInfo.id, response);
 
-        let txHash: any = await fetchJsonWithTimeout<any>(
-          'https://api.keepkey.info/api/v1/broadcastTx',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ caip, signedTx: signedTx.serializedTx || signedTx }),
-          },
-          { timeoutMs: 15000, retries: 1 },
-        );
-        if (txHash.txHash) txHash = txHash.txHash;
-        if (txHash.txid) txHash = txHash.txid;
+        const txHash: any = await broadcastViaPioneer(caip, signedTx.serializedTx || signedTx);
 
         response.txid = txHash;
         await requestStorage.updateEventById(requestInfo.id, response);

--- a/chrome-extension/src/background/chains/dashHandler.ts
+++ b/chrome-extension/src/background/chains/dashHandler.ts
@@ -4,7 +4,7 @@ import { Chain, ChainToNetworkId, shortListSymbolToCaip, caipToNetworkId } from 
 import * as wallet from '../wallet';
 import { utxoAccountFromPubkeyRow } from '../utxoDerive';
 import { createProviderRpcError } from '../utils';
-import { fetchJsonWithTimeout } from '../fetchUtils';
+import { fetchJsonWithTimeout, broadcastViaPioneer } from '../fetchUtils';
 
 const TAG = ' | dashHandler | ';
 
@@ -97,17 +97,7 @@ export const handleDashRequest = async (
         response.signedTx = signedTx;
         await requestStorage.updateEventById(requestInfo.id, response);
 
-        let txHash: any = await fetchJsonWithTimeout<any>(
-          'https://api.keepkey.info/api/v1/broadcastTx',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ caip, signedTx: signedTx.serializedTx || signedTx }),
-          },
-          { timeoutMs: 15000, retries: 1 },
-        );
-        if (txHash.txHash) txHash = txHash.txHash;
-        if (txHash.txid) txHash = txHash.txid;
+        const txHash: any = await broadcastViaPioneer(caip, signedTx.serializedTx || signedTx);
         response.txid = txHash;
         await requestStorage.updateEventById(requestInfo.id, response);
         chrome.runtime.sendMessage({

--- a/chrome-extension/src/background/chains/dogecoinHandler.ts
+++ b/chrome-extension/src/background/chains/dogecoinHandler.ts
@@ -4,7 +4,7 @@ import { Chain, ChainToNetworkId, shortListSymbolToCaip, caipToNetworkId } from 
 import * as wallet from '../wallet';
 import { utxoAccountFromPubkeyRow } from '../utxoDerive';
 import { createProviderRpcError } from '../utils';
-import { fetchJsonWithTimeout } from '../fetchUtils';
+import { fetchJsonWithTimeout, broadcastViaPioneer } from '../fetchUtils';
 
 const TAG = ' | dogecoinHandler | ';
 
@@ -100,17 +100,7 @@ export const handleDogecoinRequest = async (
         response.signedTx = signedTx;
         await requestStorage.updateEventById(requestInfo.id, response);
 
-        let txHash: any = await fetchJsonWithTimeout<any>(
-          'https://api.keepkey.info/api/v1/broadcastTx',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ caip, signedTx: signedTx.serializedTx || signedTx }),
-          },
-          { timeoutMs: 15000, retries: 1 },
-        );
-        if (txHash.txHash) txHash = txHash.txHash;
-        if (txHash.txid) txHash = txHash.txid;
+        const txHash: any = await broadcastViaPioneer(caip, signedTx.serializedTx || signedTx);
         response.txid = txHash;
         await requestStorage.updateEventById(requestInfo.id, response);
         chrome.runtime.sendMessage({

--- a/chrome-extension/src/background/chains/litecoinHandler.ts
+++ b/chrome-extension/src/background/chains/litecoinHandler.ts
@@ -4,7 +4,7 @@ import { Chain, ChainToNetworkId, shortListSymbolToCaip, caipToNetworkId } from 
 import * as wallet from '../wallet';
 import { utxoAccountFromPubkeyRow } from '../utxoDerive';
 import { createProviderRpcError } from '../utils';
-import { fetchJsonWithTimeout } from '../fetchUtils';
+import { fetchJsonWithTimeout, broadcastViaPioneer } from '../fetchUtils';
 
 const TAG = ' | litecoinHandler | ';
 
@@ -97,17 +97,7 @@ export const handleLitecoinRequest = async (
         response.signedTx = signedTx;
         await requestStorage.updateEventById(requestInfo.id, response);
 
-        let txHash: any = await fetchJsonWithTimeout<any>(
-          'https://api.keepkey.info/api/v1/broadcastTx',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ caip, signedTx: signedTx.serializedTx || signedTx }),
-          },
-          { timeoutMs: 15000, retries: 1 },
-        );
-        if (txHash.txHash) txHash = txHash.txHash;
-        if (txHash.txid) txHash = txHash.txid;
+        const txHash: any = await broadcastViaPioneer(caip, signedTx.serializedTx || signedTx);
         response.txid = txHash;
         await requestStorage.updateEventById(requestInfo.id, response);
         chrome.runtime.sendMessage({

--- a/chrome-extension/src/background/chains/mayaHandler.ts
+++ b/chrome-extension/src/background/chains/mayaHandler.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Chain, ChainToNetworkId, shortListSymbolToCaip, caipToNetworkId } from '../chainConfig';
 import * as wallet from '../wallet';
 import { createProviderRpcError } from '../utils';
-import { fetchJsonWithTimeout } from '../fetchUtils';
+import { fetchJsonWithTimeout, broadcastViaPioneer } from '../fetchUtils';
 
 const TAG = ' | mayaHandler | ';
 
@@ -95,17 +95,7 @@ export const handleMayaRequest = async (
         response.signedTx = signedTx;
         await requestStorage.updateEventById(requestInfo.id, response);
 
-        let txHash: any = await fetchJsonWithTimeout<any>(
-          'https://api.keepkey.info/api/v1/broadcastTx',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ caip, signedTx: signedTx.serializedTx || signedTx }),
-          },
-          { timeoutMs: 15000, retries: 1 },
-        );
-        if (txHash.txHash) txHash = txHash.txHash;
-        if (txHash.txid) txHash = txHash.txid;
+        const txHash: any = await broadcastViaPioneer(caip, signedTx.serializedTx || signedTx);
 
         response.txid = txHash;
         await requestStorage.updateEventById(requestInfo.id, response);

--- a/chrome-extension/src/background/chains/osmosisHandler.ts
+++ b/chrome-extension/src/background/chains/osmosisHandler.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Chain, ChainToNetworkId, shortListSymbolToCaip, caipToNetworkId } from '../chainConfig';
 import * as wallet from '../wallet';
 import { createProviderRpcError } from '../utils';
-import { fetchJsonWithTimeout } from '../fetchUtils';
+import { fetchJsonWithTimeout, broadcastViaPioneer } from '../fetchUtils';
 
 const TAG = ' | osmosisHandler | ';
 
@@ -95,17 +95,7 @@ export const handleOsmosisRequest = async (
         response.signedTx = signedTx;
         await requestStorage.updateEventById(requestInfo.id, response);
 
-        let txHash: any = await fetchJsonWithTimeout<any>(
-          'https://api.keepkey.info/api/v1/broadcastTx',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ caip, signedTx: signedTx.serializedTx || signedTx }),
-          },
-          { timeoutMs: 15000, retries: 1 },
-        );
-        if (txHash.txHash) txHash = txHash.txHash;
-        if (txHash.txid) txHash = txHash.txid;
+        const txHash: any = await broadcastViaPioneer(caip, signedTx.serializedTx || signedTx);
 
         response.txid = txHash;
         await requestStorage.updateEventById(requestInfo.id, response);

--- a/chrome-extension/src/background/chains/rippleHandler.ts
+++ b/chrome-extension/src/background/chains/rippleHandler.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Chain, ChainToNetworkId, shortListSymbolToCaip, caipToNetworkId } from '../chainConfig';
 import * as wallet from '../wallet';
 import { createProviderRpcError } from '../utils';
-import { fetchJsonWithTimeout } from '../fetchUtils';
+import { fetchJsonWithTimeout, broadcastViaPioneer } from '../fetchUtils';
 
 const TAG = ' | rippleHandler | ';
 
@@ -95,17 +95,7 @@ export const handleRippleRequest = async (
         response.signedTx = signedTx;
         await requestStorage.updateEventById(requestInfo.id, response);
 
-        let txHash: any = await fetchJsonWithTimeout<any>(
-          'https://api.keepkey.info/api/v1/broadcastTx',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ caip, signedTx: signedTx.serializedTx || signedTx }),
-          },
-          { timeoutMs: 15000, retries: 1 },
-        );
-        if (txHash.txHash) txHash = txHash.txHash;
-        if (txHash.txid) txHash = txHash.txid;
+        const txHash: any = await broadcastViaPioneer(caip, signedTx.serializedTx || signedTx);
 
         response.txid = txHash;
         await requestStorage.updateEventById(requestInfo.id, response);

--- a/chrome-extension/src/background/chains/thorchainHandler.ts
+++ b/chrome-extension/src/background/chains/thorchainHandler.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Chain, ChainToNetworkId, shortListSymbolToCaip, caipToNetworkId } from '../chainConfig';
 import * as wallet from '../wallet';
 import { createProviderRpcError } from '../utils';
-import { fetchJsonWithTimeout } from '../fetchUtils';
+import { fetchJsonWithTimeout, broadcastViaPioneer } from '../fetchUtils';
 
 const TAG = ' | thorchainHandler | ';
 
@@ -99,17 +99,7 @@ export const handleThorchainRequest = async (
         await requestStorage.updateEventById(requestInfo.id, response);
 
         // Broadcast via Pioneer API.
-        let txHash: any = await fetchJsonWithTimeout<any>(
-          'https://api.keepkey.info/api/v1/broadcastTx',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ caip, signedTx: signedTx.serializedTx || signedTx }),
-          },
-          { timeoutMs: 15000, retries: 1 },
-        );
-        if (txHash.txHash) txHash = txHash.txHash;
-        if (txHash.txid) txHash = txHash.txid;
+        const txHash: any = await broadcastViaPioneer(caip, signedTx.serializedTx || signedTx);
 
         response.txid = txHash;
         await requestStorage.updateEventById(requestInfo.id, response);


### PR DESCRIPTION
## What

Finishes the broadcast migration that #117 half-landed. #117 committed the shared `broadcastViaPioneer()` helper but left its 10 callers uncommitted, so the helper merged to `develop` as dead code. This wires up the callers.

**BTC, BCH, DASH, DOGE, LTC, Cosmos, Osmosis, Maya, Thorchain, Ripple** now broadcast through `broadcastViaPioneer()` → `POST /api/v1/broadcast`, instead of each inlining a POST to the legacy `/api/v1/broadcastTx` alias.

## Why it's safe (behavior-preserving)

`/broadcastTx` is a **server-side compatibility shim** (`pioneer legacy-broadcast.ts` → `buildBroadcastBodyFromLegacy`): it maps the old `{ caip, signedTx }` shape to the canonical `{ networkId, serialized }` (via `caip.split('/')[0]`) and calls the same `BroadcastController.Broadcast()`. `broadcastViaPioneer` performs that identical `caip → networkId` split client-side, so **the value reaching the controller is byte-identical** in both paths.

Each of the 10 diffs is the same mechanical swap:
```diff
-let txHash = await fetchJsonWithTimeout('.../broadcastTx', { body: { caip, signedTx: signedTx.serializedTx || signedTx } }, ...);
-if (txHash.txHash) txHash = txHash.txHash;
-if (txHash.txid) txHash = txHash.txid;
+const txHash = await broadcastViaPioneer(caip, signedTx.serializedTx || signedTx);
```

## Verified

- `/api/v1/broadcast` is **live in prod** (`api.keepkey.info` returns validation, not 404) and its controller handles every migrated networkId (UTXO/Cosmos/Ripple maps).
- No Pioneer-side change needed; `/broadcastTx` alias stays up for older deployed extensions.
- No new fund-safety gap: the old inline path also threw-on-failure with `retries: 1`; `broadcastViaPioneer` preserves that. (UTXO/Cosmos/Ripple replay protection makes the Solana-style double-send far less applicable, and this diff doesn't change that behavior.)
- `make type-check` 15/15, `make test` 111/111, `make build` 9/9. No leftover `/broadcastTx` refs; no unused imports.

Removes ~120 lines of duplicated inline broadcast code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)