### PR TITLE
feat(bex): MCP visualization + tool-driving fixes (window, overlay, panel)

### DIFF
--- a/chrome-extension/manifest.js
+++ b/chrome-extension/manifest.js
@@ -37,7 +37,7 @@ const manifest = deepmerge(
     version: packageJson.version,
     description: '__MSG_extensionDescription__',
     host_permissions: ['<all_urls>'],
-    permissions: ['storage', 'tabs', 'commands'],
+    permissions: ['storage', 'tabs', 'commands', 'scripting'],
     options_page: 'options/index.html',
     background: {
       service_worker: 'background.iife.js',

--- a/chrome-extension/src/background/browserTools.ts
+++ b/chrome-extension/src/background/browserTools.ts
@@ -12,9 +12,9 @@
  * ponytail: Playwright/Puppeteer are not options here even if we wanted them —
  * the background bundles to one IIFE with no Node builtins (no `net`), so they
  * cannot run in-extension at all. chrome.tabs + a content script cover this with
- * zero new dependencies and, notably, zero new permissions: `<all_urls>` and
- * `tabs` are already granted (manifest.js:39-40) and the content script is
- * already at document_start on every http/https page.
+ * zero new dependencies and no new install warnings: `<all_urls>` and `tabs`
+ * were already granted, and `scripting` (late injection in dom()) warns nothing
+ * beyond the host access the user already approved.
  *
  * Contract with the DOM half (pages/content/src/agentDom.ts): one message per
  * op, refs minted page-side. See that file for why refs beat selectors.
@@ -239,16 +239,24 @@ async function resolveTab(tabId?: number): Promise<chrome.tabs.Tab> {
 
 /** Ask the page-side agentDom to do something, and normalize its failures. */
 async function dom(tabId: number, op: string, payload: Record<string, unknown> = {}): Promise<any> {
+  const send = () => chrome.tabs.sendMessage(tabId, { type: 'BEX_AGENT_DOM', op, ...payload });
   let res: any;
   try {
-    res = await chrome.tabs.sendMessage(tabId, { type: 'BEX_AGENT_DOM', op, ...payload });
+    res = await send();
   } catch {
-    // No content script in this tab. Either it predates the extension load, or
-    // it's a chrome:// / Web Store / PDF page where content scripts never run.
-    throw err(
-      'no_content_script',
-      `cannot reach tab ${tabId} — reload the page (or use bex_navigate); chrome:// and Web Store pages can never be driven`,
-    );
+    // sendMessage threw = no receiver in any frame = the content bundle never
+    // ran here (tab predates the extension load). Inject it and retry once —
+    // safe from double-boot precisely because the throw proves it's absent.
+    try {
+      await chrome.scripting.executeScript({ target: { tabId }, files: ['content/index.iife.js'] });
+      res = await send();
+    } catch {
+      // Injection refused: chrome:// / Web Store / PDF viewer. Not drivable, ever.
+      throw err(
+        'undriveable_page',
+        `cannot drive tab ${tabId} — Chrome blocks extensions on chrome://, Web Store and PDF pages; pick a normal web tab (bex_tabs lists them)`,
+      );
+    }
   }
   if (!res) throw err('no_content_script', `tab ${tabId} did not answer — reload the page`);
   if (!res.ok) throw err(res.code ?? 'dom_error', res.message ?? 'DOM operation failed');
@@ -310,6 +318,18 @@ function formatSnapshot(snap: { url: string; title: string; nodes: any[] }): str
 }
 
 async function screenshot(tab: chrome.tabs.Tab, quality: number): Promise<Content> {
+  // captureVisibleTab refuses privileged pages, but with a misleading message
+  // about the activeTab permission. Catch them up front with an honest one.
+  if (
+    tab.url &&
+    (/^(chrome|chrome-extension|devtools|edge|about|view-source):/.test(tab.url) ||
+      tab.url.startsWith('https://chromewebstore.google.com'))
+  ) {
+    throw err(
+      'uncapturable_page',
+      `Chrome refuses to capture ${new URL(tab.url).protocol}// pages — pass the tabId of a normal web tab (bex_tabs lists them)`,
+    );
+  }
   // Chrome can only capture the ACTIVE tab of a window, so focus it first. This
   // is a visible side effect and is called out in the tool description.
   if (!tab.active && tab.id != null) await chrome.tabs.update(tab.id, { active: true });

--- a/chrome-extension/src/background/browserTools.ts
+++ b/chrome-extension/src/background/browserTools.ts
@@ -38,13 +38,17 @@ export const BROWSER_TOOLS = [
   {
     name: 'bex_tabs',
     description:
-      "List, create, close, or focus browser tabs in the user's real Chrome. action=list returns each tab's id, url, title and whether it is active.",
+      "List, create, close, or focus tabs — or open a new browser window — in the user's real Chrome. action=list returns each tab's id, url, title, windowId and whether it is active. action=create opens a tab in the current window; action=new-window opens a separate browser window.",
     inputSchema: {
       type: 'object',
       properties: {
-        action: { type: 'string', enum: ['list', 'create', 'close', 'select'], description: 'Default: list' },
+        action: {
+          type: 'string',
+          enum: ['list', 'create', 'close', 'select', 'new-window'],
+          description: 'Default: list. create=new tab in current window; new-window=new browser window',
+        },
         tabId: { type: 'number', description: 'Target tab for close/select' },
-        url: { type: 'string', description: 'URL for create' },
+        url: { type: 'string', description: 'URL for create / new-window' },
       },
       additionalProperties: false,
     },
@@ -220,6 +224,37 @@ export const BROWSER_TOOLS = [
       additionalProperties: false,
     },
   },
+  {
+    name: 'bex_bring_to_front',
+    description:
+      "Raise the browser window to the front of the screen so the user can WATCH what you do. Call it when you START a browser task and whenever you switch windows — otherwise your work happens behind other windows and the user has to go hunting for it. Un-minimizes the window and activates the tab. (Focus within Chrome is reliable; whether the OS pulls Chrome above other apps is best-effort — the extension can't force it.) Omit tabId to raise the active window.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: { type: 'number', description: 'Raise the window containing this tab; default = active window' },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'bex_panel',
+    description:
+      "Control the in-page status panel the user watches while you drive. action=status raises a prominent message — use level='action-needed' for the moment a KeepKey button-press is required (call it right BEFORE you trigger a device signature, e.g. \"Confirm the swap on your KeepKey\"), and level='done' when it's handled. action=show/hide toggles the panel; the action log fills itself as you click/type. Note: the panel canNOT open Chrome's wallet side panel — that needs a user gesture the MCP lacks, so the panel just shows the user where to click. Omit tabId for the active tab.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: { type: 'string', enum: ['show', 'hide', 'status'], description: 'Default: show' },
+        message: { type: 'string', description: 'Status text (action=status)' },
+        level: {
+          type: 'string',
+          enum: ['info', 'action-needed', 'done'],
+          description: "action=status level; 'action-needed' = waiting on a KeepKey button press",
+        },
+        tabId: { type: 'number' },
+      },
+      additionalProperties: false,
+    },
+  },
 ];
 
 async function activeTab(): Promise<chrome.tabs.Tab> {
@@ -333,7 +368,15 @@ async function screenshot(tab: chrome.tabs.Tab, quality: number): Promise<Conten
   // Chrome can only capture the ACTIVE tab of a window, so focus it first. This
   // is a visible side effect and is called out in the tool description.
   if (!tab.active && tab.id != null) await chrome.tabs.update(tab.id, { active: true });
-  const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId!, { format: 'jpeg', quality });
+  // Hide the agent overlay so it doesn't land in the capture; best-effort (the
+  // page may have no content script). It resolves after a painted frame.
+  if (tab.id != null) await dom(tab.id, 'overlay', { show: false }).catch(() => {});
+  let dataUrl: string;
+  try {
+    dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId!, { format: 'jpeg', quality });
+  } finally {
+    if (tab.id != null) void dom(tab.id, 'overlay', { show: true }).catch(() => {});
+  }
 
   const binary = atob(dataUrl.split(',')[1]);
   const bytes = new Uint8Array(binary.length);
@@ -365,6 +408,12 @@ export async function executeBrowserTool(tool: string, args: any): Promise<any> 
         const tab = await chrome.tabs.create({ url: args?.url, active: true });
         if (args?.url && tab.id != null) await waitForLoad(tab.id, { settledIsDone: true });
         return { tabId: tab.id, url: tab.url };
+      }
+      if (action === 'new-window') {
+        const win = await chrome.windows.create({ url: args?.url, focused: true });
+        const tab = win.tabs?.[0];
+        if (args?.url && tab?.id != null) await waitForLoad(tab.id, { settledIsDone: true });
+        return { windowId: win.id, tabId: tab?.id, url: tab?.url };
       }
       if (action === 'close') {
         const tab = await resolveTab(args?.tabId);
@@ -482,6 +531,27 @@ export async function executeBrowserTool(tool: string, args: any): Promise<any> 
       const tab = await resolveTab(args?.tabId);
       const quality = Math.min(100, Math.max(1, Number(args?.quality) || SCREENSHOT_QUALITY));
       return screenshot(tab, quality);
+    }
+
+    case 'bex_panel': {
+      const tab = await resolveTab(args?.tabId);
+      const action = args?.action ?? 'show';
+      if (action === 'hide') return dom(tab.id!, 'panel', { action: 'hide' });
+      if (action === 'status')
+        return dom(tab.id!, 'panel', { message: args?.message ?? '', level: args?.level ?? 'info' });
+      return dom(tab.id!, 'panel', {});
+    }
+
+    case 'bex_bring_to_front': {
+      const tab = await resolveTab(args?.tabId);
+      const win = await chrome.windows.get(tab.windowId!);
+      // focused raises the window; only force state:'normal' when minimized so
+      // we don't un-maximize a maximized window.
+      const update: chrome.windows.UpdateInfo = { focused: true };
+      if (win.state === 'minimized') update.state = 'normal';
+      await chrome.windows.update(tab.windowId!, update);
+      if (tab.id != null && !tab.active) await chrome.tabs.update(tab.id, { active: true });
+      return { windowId: tab.windowId, tabId: tab.id, focused: true };
     }
 
     default:

--- a/chrome-extension/src/background/chains/ethereumHandler.ts
+++ b/chrome-extension/src/background/chains/ethereumHandler.ts
@@ -466,7 +466,10 @@ const handleWalletSwitchEthereumChain = async (params: any, KEEPKEY_WALLET: any,
   const storedChainData = await blockchainDataStorage.getBlockchainData(networkId);
   if (storedChainData) {
     console.log(tag, 'Chain found in custom storage, switching...');
-    await switchToProvider(storedChainData, KEEPKEY_WALLET, tag);
+    // Records are keyed by networkId but older writes (including our own
+    // Pioneer-provision path) didn't embed it, and switchToProvider
+    // hard-requires it — stamp the key back onto the record.
+    await switchToProvider({ networkId, ...storedChainData }, KEEPKEY_WALLET, tag);
     return null;
   }
 
@@ -480,6 +483,7 @@ const handleWalletSwitchEthereumChain = async (params: any, KEEPKEY_WALLET: any,
     console.log(tag, 'Chain found in Pioneer registry, provisioning + switching...');
     try {
       await blockchainDataStorage.addBlockchainData(networkId, {
+        networkId,
         chainId: pioneerChain.chainId,
         caip: pioneerChain.caip,
         name: pioneerChain.name,

--- a/pages/content/src/agentDom.ts
+++ b/pages/content/src/agentDom.ts
@@ -21,8 +21,19 @@
 
 import { getPageConsole } from './consoleBridge';
 import { pullObs } from './obsBridge';
+import { overlayAct, overlaySetVisible } from './agentOverlay';
+import { panelShow, panelHide, panelLog, panelStatus } from './agentPanel';
 
 const TAG = ' | agentDom | ';
+
+// Let the pointer/highlight land before the action fires, so the user sees WHAT
+// is being acted on. Hardware-wallet flows are slow anyway, so this is free.
+const SHOW_MS = 420;
+const showThen = (kind: string, el: Element, detail: string) => {
+  overlayAct(kind, el, detail);
+  panelLog(detail ? `${kind}: ${detail}` : kind);
+  return new Promise<void>(r => setTimeout(r, SHOW_MS));
+};
 
 const STORAGE_MAX_KEYS = 200;
 const STORAGE_VALUE_CLIP = 1000;
@@ -383,12 +394,16 @@ async function handle(msg: any): Promise<any> {
     case 'snapshot':
       return snapshot();
 
-    case 'click':
-      fireClick(resolve(msg.ref));
+    case 'click': {
+      const el = resolve(msg.ref);
+      await showThen('clicking', el, nameOf(el));
+      fireClick(el);
       return { clicked: msg.ref };
+    }
 
     case 'type': {
       const el = resolve(msg.ref);
+      await showThen('typing', el, String(msg.text ?? '').slice(0, 40));
       setValue(el, String(msg.text ?? ''));
       if (msg.submit) {
         const key = { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true, composed: true };
@@ -407,6 +422,7 @@ async function handle(msg: any): Promise<any> {
       if (!(el instanceof HTMLSelectElement)) {
         throw Object.assign(new Error('element is not a <select>'), { code: 'not_editable' });
       }
+      await showThen('selecting', el, String(msg.value ?? '').slice(0, 40));
       el.value = String(msg.value);
       el.dispatchEvent(new Event('input', { bubbles: true }));
       el.dispatchEvent(new Event('change', { bubbles: true }));
@@ -429,6 +445,20 @@ async function handle(msg: any): Promise<any> {
 
     case 'storage':
       return readStorage();
+
+    case 'overlay':
+      await overlaySetVisible(msg.show !== false);
+      return { overlay: msg.show !== false };
+
+    case 'panel': {
+      if (msg.action === 'hide') {
+        panelHide();
+        return { panel: 'hidden' };
+      }
+      if (msg.message != null || msg.level) panelStatus(String(msg.message ?? ''), msg.level ?? 'info');
+      else panelShow();
+      return { panel: 'shown' };
+    }
 
     case 'find': {
       // Search the snapshot page-side and return only the hits, so the agent can

--- a/pages/content/src/agentOverlay.ts
+++ b/pages/content/src/agentOverlay.ts
@@ -1,0 +1,170 @@
+/**
+ * agentOverlay — a real-time visual layer so the user can WATCH the MCP agent
+ * work: an animated pointer glides to each target, the target is outlined, a
+ * caption names the action, and a top banner shows the tab is being driven.
+ *
+ * Isolated-world DOM, `pointer-events:none` throughout — it never intercepts the
+ * agent's clicks or the user's, and never changes layout (everything is
+ * position:fixed). The agent acts in discrete steps, so this highlights each
+ * action as it happens rather than mirroring a continuous cursor.
+ *
+ * ponytail: pure DOM + CSS transitions, no deps, no new permissions. All draws
+ * are wrapped in try/catch — a broken overlay must never break a wallet action.
+ */
+
+const ROOT_ID = '__bex_agent_overlay';
+const Z = 2147483647; // max z-index — sit above everything the page draws
+const HIGHLIGHT_MS = 1100; // how long the box + label linger after an action
+const BANNER_IDLE_MS = 8000; // hide the "driving" banner after this much quiet
+const GOLD = '#d29929'; // brand token
+
+let root: HTMLElement | null = null;
+let box: HTMLElement | null = null;
+let label: HTMLElement | null = null;
+let cursor: HTMLElement | null = null;
+let banner: HTMLElement | null = null;
+let fadeTimer: ReturnType<typeof setTimeout> | undefined;
+let bannerTimer: ReturnType<typeof setTimeout> | undefined;
+
+function el(styles: Partial<CSSStyleDeclaration>): HTMLElement {
+  const n = document.createElement('div');
+  Object.assign(n.style, styles);
+  return n;
+}
+
+function ensureRoot(): boolean {
+  if (root && root.isConnected) return true;
+  const host = document.body || document.documentElement;
+  if (!host) return false;
+
+  root = el({ position: 'fixed', inset: '0', pointerEvents: 'none', zIndex: String(Z) });
+
+  banner = el({
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    right: '0',
+    height: '28px',
+    display: 'none',
+    alignItems: 'center',
+    padding: '0 12px',
+    font: '600 13px/28px -apple-system,system-ui,sans-serif',
+    color: '#fff',
+    background: `linear-gradient(90deg,${GOLD},#b8801f)`,
+    boxShadow: '0 1px 6px rgba(0,0,0,.3)',
+    pointerEvents: 'none',
+  });
+  banner.textContent = '🤖 MCP is driving this tab';
+
+  box = el({
+    position: 'fixed',
+    border: `2px solid ${GOLD}`,
+    borderRadius: '4px',
+    boxShadow: `0 0 0 2px rgba(210,153,41,.35), 0 0 14px rgba(210,153,41,.55)`,
+    transition: 'all .18s ease-out',
+    opacity: '0',
+    pointerEvents: 'none',
+  });
+
+  label = el({
+    position: 'fixed',
+    padding: '2px 8px',
+    borderRadius: '4px',
+    font: '600 12px/1.5 -apple-system,system-ui,sans-serif',
+    color: '#fff',
+    background: GOLD,
+    whiteSpace: 'nowrap',
+    maxWidth: '60vw',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    opacity: '0',
+    transition: 'opacity .18s ease-out',
+    boxShadow: '0 1px 4px rgba(0,0,0,.3)',
+    pointerEvents: 'none',
+  });
+
+  cursor = el({
+    position: 'fixed',
+    left: '0',
+    top: '0',
+    width: '24px',
+    height: '24px',
+    transform: 'translate(-100px,-100px)',
+    transition: 'transform .4s cubic-bezier(.22,.61,.36,1)',
+    opacity: '0',
+    pointerEvents: 'none',
+    filter: 'drop-shadow(0 1px 2px rgba(0,0,0,.4))',
+  });
+  cursor.innerHTML =
+    '<svg width="24" height="24" viewBox="0 0 24 24" fill="none">' +
+    `<path d="M5 3l14 7-6 1.5L10 18 5 3z" fill="${GOLD}" stroke="#fff" stroke-width="1.2" stroke-linejoin="round"/>` +
+    '</svg>';
+
+  root.append(banner, box, label, cursor);
+  host.appendChild(root);
+  return true;
+}
+
+function showBanner(): void {
+  if (!banner) return;
+  banner.style.display = 'flex';
+  clearTimeout(bannerTimer);
+  bannerTimer = setTimeout(() => {
+    if (banner) banner.style.display = 'none';
+    if (cursor) cursor.style.opacity = '0';
+  }, BANNER_IDLE_MS);
+}
+
+/** Point at + outline `target` and caption the action. Best-effort, never throws. */
+export function overlayAct(kind: string, target: Element, detail: string): void {
+  try {
+    if (!ensureRoot() || !box || !label || !cursor) return;
+    const r = target.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) return; // off-screen / detached — nothing to point at
+
+    Object.assign(box.style, {
+      left: `${r.left - 3}px`,
+      top: `${r.top - 3}px`,
+      width: `${r.width + 6}px`,
+      height: `${r.height + 6}px`,
+      opacity: '1',
+    });
+
+    // Caption above the target, or below if there's no room at the top.
+    const above = r.top - 26 > 30;
+    Object.assign(label.style, {
+      left: `${Math.max(4, r.left)}px`,
+      top: `${above ? r.top - 26 : r.bottom + 6}px`,
+      opacity: '1',
+    });
+    label.textContent = detail ? `${kind}: ${detail}` : kind;
+
+    // Pointer glides to the target's centre (the .4s CSS transition animates it).
+    cursor.style.transform = `translate(${r.left + r.width / 2 - 4}px,${r.top + r.height / 2 - 2}px)`;
+    cursor.style.opacity = '1';
+
+    showBanner();
+
+    clearTimeout(fadeTimer);
+    fadeTimer = setTimeout(() => {
+      if (box) box.style.opacity = '0';
+      if (label) label.style.opacity = '0';
+    }, HIGHLIGHT_MS);
+  } catch {
+    /* overlay must never break an action */
+  }
+}
+
+/**
+ * Hide/show the whole overlay. Used to keep bex_screenshot captures clean.
+ * When hiding, resolves only after a painted frame so the capture sees it gone.
+ */
+export function overlaySetVisible(show: boolean): Promise<void> {
+  try {
+    if (root) root.style.visibility = show ? 'visible' : 'hidden';
+  } catch {
+    /* ignore */
+  }
+  if (show) return Promise.resolve();
+  return new Promise(res => requestAnimationFrame(() => requestAnimationFrame(() => res())));
+}

--- a/pages/content/src/agentPanel.ts
+++ b/pages/content/src/agentPanel.ts
@@ -1,0 +1,175 @@
+/**
+ * agentPanel — a persistent, MCP-controllable status drawer mounted in the page
+ * (isolated world). Unlike the transient overlay (pointer/box), this stays put
+ * and shows:
+ *   - a live log of what the agent is doing (fed from every click/type/select),
+ *   - a device-action alert the MCP raises when a KeepKey button-press is needed,
+ *   - a hint for opening the real wallet side panel — which Chrome won't let the
+ *     MCP auto-open (sidePanel.open needs a user gesture the MCP doesn't have),
+ *     so we point the user at the toolbar icon instead.
+ *
+ * ponytail: pure DOM + CSS, no deps. The MCP sets the device-action message
+ * itself (bex_panel) rather than us plumbing live device state through the
+ * background — the agent driving the sign already knows the moment it happens.
+ */
+
+const PANEL_ID = '__bex_agent_panel';
+const GOLD = '#d29929';
+const MAX_LOG = 8;
+
+let panel: HTMLElement | null = null;
+let statusEl: HTMLElement | null = null;
+let logEl: HTMLElement | null = null;
+const logLines: string[] = [];
+
+function css(n: HTMLElement, styles: Partial<CSSStyleDeclaration>): HTMLElement {
+  Object.assign(n.style, styles);
+  return n;
+}
+function mk(tag: string, styles: Partial<CSSStyleDeclaration> = {}): HTMLElement {
+  return css(document.createElement(tag), styles);
+}
+
+/** The KeepKey toolbar icon, redrawn small so the hint shows what to click. */
+const KK_ICON =
+  '<svg width="18" height="18" viewBox="0 0 24 24" fill="none">' +
+  '<rect x="2" y="2" width="20" height="20" rx="5" fill="#0d1117"/>' +
+  '<path d="M8 6v12M8 12l6-6M8 12l6 6" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>' +
+  '<circle cx="18" cy="18" r="3" fill="#3fb950" stroke="#0d1117" stroke-width="1.4"/>' +
+  '</svg>';
+
+function ensurePanel(): boolean {
+  if (panel && panel.isConnected) return true;
+  const host = document.body || document.documentElement;
+  if (!host) return false;
+
+  panel = mk('div', {
+    position: 'fixed',
+    top: '48px',
+    right: '0',
+    width: '248px',
+    maxHeight: '70vh',
+    display: 'flex',
+    flexDirection: 'column',
+    background: '#161b22',
+    color: '#e6edf3',
+    font: '13px/1.45 -apple-system,system-ui,sans-serif',
+    border: '1px solid #30363d',
+    borderRight: 'none',
+    borderRadius: '10px 0 0 10px',
+    boxShadow: '0 6px 24px rgba(0,0,0,.4)',
+    zIndex: '2147483646', // just under the transient overlay
+    transform: 'translateX(110%)',
+    transition: 'transform .28s cubic-bezier(.22,.61,.36,1)',
+    overflow: 'hidden',
+  });
+
+  const header = mk('div', {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '9px 12px',
+    fontWeight: '700',
+    background: `linear-gradient(90deg,${GOLD},#b8801f)`,
+    color: '#fff',
+  });
+  header.innerHTML = '<span>🤖 KeepKey MCP</span>';
+  const close = css(mk('button'), {
+    marginLeft: 'auto',
+    cursor: 'pointer',
+    border: 'none',
+    background: 'transparent',
+    color: '#fff',
+    font: '700 16px/1 sans-serif',
+    padding: '0 2px',
+  });
+  close.textContent = '×';
+  close.setAttribute('aria-label', 'Hide MCP panel');
+  close.addEventListener('click', panelHide);
+  header.appendChild(close);
+
+  statusEl = mk('div', { display: 'none', padding: '10px 12px', fontWeight: '600' });
+
+  logEl = mk('div', {
+    padding: '8px 12px',
+    overflowY: 'auto',
+    flex: '1',
+    fontVariantNumeric: 'tabular-nums',
+    color: '#9aa4b2',
+  });
+
+  const hint = mk('div', {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '9px 12px',
+    borderTop: '1px solid #30363d',
+    background: '#0d1117',
+    color: '#9aa4b2',
+    fontSize: '12px',
+  });
+  hint.innerHTML =
+    `<span style="flex:0 0 auto">${KK_ICON}</span>` +
+    '<span>Open the full wallet: click the KeepKey icon in your toolbar <b style="color:#e6edf3">↗</b></span>';
+
+  panel.append(header, statusEl, logEl, hint);
+  host.appendChild(panel);
+  return true;
+}
+
+export function panelShow(): void {
+  try {
+    if (ensurePanel() && panel) panel.style.transform = 'translateX(0)';
+  } catch {
+    /* never break an action */
+  }
+}
+
+export function panelHide(): void {
+  try {
+    if (panel) panel.style.transform = 'translateX(110%)';
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Append one action line to the log and reveal the panel. */
+export function panelLog(line: string): void {
+  try {
+    if (!ensurePanel() || !logEl) return;
+    logLines.push(line);
+    while (logLines.length > MAX_LOG) logLines.shift();
+    logEl.textContent = '';
+    for (const l of logLines) {
+      const row = mk('div', { padding: '1px 0' });
+      row.textContent = `• ${l}`;
+      logEl.appendChild(row);
+    }
+    logEl.scrollTop = logEl.scrollHeight;
+    panelShow();
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Raise a prominent status line — used for "confirm on your KeepKey". */
+export function panelStatus(message: string, level: 'info' | 'action-needed' | 'done'): void {
+  try {
+    if (!ensurePanel() || !statusEl) return;
+    if (!message) {
+      statusEl.style.display = 'none';
+      return;
+    }
+    const style: Record<string, { bg: string; fg: string; icon: string }> = {
+      info: { bg: '#1f2937', fg: '#9aa4b2', icon: 'ℹ️' },
+      'action-needed': { bg: 'rgba(210,153,41,.18)', fg: GOLD, icon: '👆' },
+      done: { bg: 'rgba(63,185,80,.15)', fg: '#3fb950', icon: '✓' },
+    };
+    const s = style[level] ?? style.info;
+    css(statusEl, { display: 'block', background: s.bg, color: s.fg });
+    statusEl.textContent = `${s.icon} ${message}`;
+    panelShow();
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
Bundles the `fix/bex-tool-quirks` work: two driving-reliability fixes plus the MCP-visualization feature set. All client-side — the vault dumb-pipe auto-advertises the new tools (**21 total**), no vault change.

## Commits

### `feat` — MCP visualization (make driving watchable)
The user shouldn't have to hunt for where the agent is working.
- **`bex_bring_to_front`** — raise the Chrome window (focus + un-minimize) so the user can watch; agent calls it at task start / on window switch. Focus *within* Chrome is reliable; OS-level app-raise is best-effort (an extension can't force it).
- **`bex_tabs action=new-window`** — open a real separate browser window (`chrome.windows.create`), not just a tab.
- **`agentOverlay.ts`** — transient per-action layer: a gold pointer glides to each target, the element gets an outlined box + action caption, and a "🤖 MCP is driving" banner shows while active. A 420ms pre-action pause lets it land before the click fires. Auto-hides during `bex_screenshot` so captures stay clean. `pointer-events:none` + try/caught — never intercepts a click or breaks a wallet action.
- **`agentPanel.ts` + `bex_panel`** — persistent right-side drawer: live action log, a **device-action alert** the agent raises before a KeepKey button-press (`level=action-needed` → "Confirm the swap on your KeepKey"), and a hint to open the real wallet side panel by clicking the toolbar icon. (Chrome won't let the MCP open the side panel — `sidePanel.open` needs a user gesture the MCP lacks; the codebase already documents this.)

### `fix(evm)` — `wallet_switchEthereumChain` failed on every already-known chain
Pioneer-provisioned chain records were persisted without `networkId`, so the *first* switch worked (networkId passed explicitly) but every later switch loaded the stored record and died in `switchToProvider`'s missing-networkId check — Uniswap's defensive pre-swap switch-chain then silently aborted the swap. Stamp the storage key back onto the record on read, embed `networkId` on write.

### `fix(bex)` — auto-inject on pre-extension tabs; honest errors for uncapturable pages
- `dom()`: a `sendMessage` throw proves the content bundle never ran in the tab → inject `content/index.iife.js` via `chrome.scripting` and retry once. Tabs opened before the extension loaded now just work (no manual reload). Injection refused (chrome://, Web Store, PDF) → `undriveable_page` pointing at `bex_tabs`.
- `bex_screenshot`: pre-check privileged URLs → honest `uncapturable_page` instead of Chrome's misleading activeTab error.
- manifest: add `scripting` permission (no new install warning — `<all_urls>` already granted).

## Test
`make type-check` 15/15, `make build` 9/9. New tools verified live over the vault `/mcp` bridge: `tools/list` returns 21 tools; `bex_tabs new-window`, `bex_bring_to_front`, `bex_snapshot`, `bex_click` round-trip and return success.

**Not yet visually confirmed:** the overlay/panel *render* (pointer, box, banner, drawer) — the plumbing is verified end-to-end, but eyeballing the on-screen result is pending a reload-and-watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)