### PR TITLE
feat(hive): surface full account — price, HBD receive, holdings, firmware-gate

### DIFF
--- a/HANDOFF_vault_hive_addresses_500.md
+++ b/HANDOFF_vault_hive_addresses_500.md
@@ -1,0 +1,75 @@
+# HANDOFF → vault: `/addresses/hive` 500 `json is not defined` (firmware-gate crash)
+
+**From:** keepkey-client (Hive dashboard debugging, 2026-07-17)
+**Vault tree:** `/Users/highlander/WebstormProjects/keepkey-stack/projects/keepkey-vault-v11/projects/keepkey-vault`
+**File:** `src/bun/rest-api.ts` (one function)
+
+## Symptom
+
+Hive never appears in the client side-panel dashboard. Root cause traced to:
+
+```
+POST http://localhost:1646/addresses/hive  →  HTTP 500  {"error":"json is not defined"}
+```
+
+The client treats this as "no Hive account" and silently omits the row
+(`chrome-extension/src/background/chains/hiveHandler.ts` → `getHivePublicKey()`
+throws → `getHiveAccountInfo()` returns `{ok:false}` → `buildHiveUiRows()` → null).
+
+## Root cause — a lexical-scope bug
+
+`requireChainSupport()` is defined in the **outer** scope, *before* `Bun.serve`:
+
+- `src/bun/rest-api.ts:1126` — `function requireChainSupport(chainId): Response | null { … return json({…}, 501) }`
+- `src/bun/rest-api.ts:1141` — `const server = Bun.serve({`
+- `src/bun/rest-api.ts:1150` — `async fetch(req, server) {`
+- `src/bun/rest-api.ts:1184` — `const json = (…) => {…}`  ← **per-request helper, defined INSIDE `fetch`**
+
+`requireChainSupport` closes over the scope where it was *defined* (outer), so the
+per-request `json` (defined inside `fetch`) is **not in scope**. Its firmware-fail
+branch `return json({ error: '… requires firmware ≥ …' }, 501)` throws
+`ReferenceError: json is not defined`, which the outer catch turns into
+`500 {"error":"json is not defined"}`.
+
+## Why it surfaces as "Hive is broken" specifically
+
+`requireChainSupport` only reaches the `json(…, 501)` line when the device firmware
+is **below the chain's `minFirmware`**. It's called for several chains:
+
+- `rest-api.ts:2062` solana, `:2083` tron, `:2104` ton — device firmware already
+  meets their minimums → `return null` → never touches `json` → no crash (bug latent).
+- `rest-api.ts:2128` / `:2152` hive — Hive needs **7.15.0**; this device is below it
+  → hits the fail branch → **crash**.
+
+So the crash doubly hides the truth: the device *does* need a firmware update for Hive,
+but instead of the honest `501`, the client gets a `500` it can't interpret.
+
+## Fix (pick one)
+
+1. **Move `requireChainSupport` inside `fetch`** (below the `json` definition at :1184)
+   so `json` is in lexical scope. Smallest change.
+2. **Don't use the closure `json`** — have `requireChainSupport` `throw new HttpError(501, msg)`
+   and let the existing HttpError handler (`rest-api.ts:~1308`) serialize it. Cleaner; keeps
+   the helper where it is.
+
+Either restores the intended behavior: a device below `minFirmware` gets a clean
+`501 { error: "HIVE requires firmware ≥ 7.15.0 (device has X)" }` for **all** gated
+chains (solana/tron/ton/hive), not a `json is not defined` 500.
+
+## Note on the actual unblock
+
+The bug fix alone won't make Hive appear — it just turns the crash into the honest 501.
+**The device firmware must be ≥ 7.15.0** for Hive to work at all. After updating firmware,
+`/addresses/hive` returns the pubkey; then a Hive account must exist for that key
+(Pioneer `/api/v1/hive/account/{pubkey}` — `noAccount` means create one via Vault Hive onboarding).
+
+## Verify
+
+- Below-7.15 device: `POST /addresses/hive` → **501** (not 500), body names the required version.
+- 7.15+ device with a Hive account: `POST /addresses/hive` → `{ address }`, and Hive shows in the client.
+
+## Aside: running build lag
+
+The live build (`_build/dev-macos-arm64/…/app/bun/index.js`, Jul 17) also 404s
+`/system/info/get-features`, which the current source registers (`rest-api.ts:3006`) —
+so the deployed bundle trails the source tree. Worth a clean rebuild alongside the fix.

--- a/chrome-extension/src/background/chains/hiveHandler.ts
+++ b/chrome-extension/src/background/chains/hiveHandler.ts
@@ -100,9 +100,47 @@ async function getHiveAccount(): Promise<{ name: string; pubkey: string }> {
  * breaking the header. `address` is the Hive account name — that's the
  * user-facing identifier and the transfer destination.
  */
+/** The full Hive account picture beyond liquid HIVE — display-only holdings. */
+export type HiveHoldings = {
+  hbd: string; // liquid HBD (stablecoin)
+  hp: string; // Hive Power (staked HIVE, VESTS→HP)
+  hiveSavings: string;
+  hbdSavings: string;
+  pendingHive: string;
+  pendingHbd: string;
+  pendingHp: string;
+  hpDelegatedOut: string;
+  hpDelegatedIn: string;
+  rcPercent: number; // 0-100
+  poweringDown: boolean;
+  powerDownWeeklyHp: string;
+};
+
 export type HiveAccountInfo =
-  | { ok: true; name: string; pubkey: string; hive: string; hbd: string; hp: string }
+  | ({ ok: true; name: string; pubkey: string; hive: string; priceUsd: string } & HiveHoldings)
   | { ok: false; reason: string };
+
+/**
+ * HIVE price in USD from Pioneer. Pioneer's market map is keyed by the FULL
+ * CAIP-19 (`hive:beeab0de/slip44:1275`) — the networkId or 'HIVE' ticker both
+ * return 0 — so we must ask by HIVE_CAIP. Response: `{ data: [price], success }`.
+ * Returns '0' on any failure (price simply unavailable that render).
+ */
+async function fetchHivePriceUsd(): Promise<string> {
+  try {
+    const resp = await fetch(`${PIONEER_URL}/api/v1/market/info`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([HIVE_CAIP]),
+      signal: AbortSignal.timeout(15_000),
+    });
+    const data = await resp.json();
+    const price = data?.data?.[0];
+    return Number.isFinite(Number(price)) && Number(price) > 0 ? String(price) : '0';
+  } catch {
+    return '0';
+  }
+}
 
 async function fetchHiveAccountInfo(): Promise<HiveAccountInfo> {
   try {
@@ -116,7 +154,26 @@ async function fetchHiveAccountInfo(): Promise<HiveAccountInfo> {
     }
     cachedAccountName = data.account.name;
     const a = data.account;
-    return { ok: true, name: a.name, pubkey, hive: a.hive ?? '0', hbd: a.hbd ?? '0', hp: a.hp ?? '0' };
+    const priceUsd = await fetchHivePriceUsd();
+    return {
+      ok: true,
+      name: a.name,
+      pubkey,
+      hive: a.hive ?? '0',
+      priceUsd,
+      hbd: a.hbd ?? '0',
+      hp: a.hp ?? '0',
+      hiveSavings: a.hiveSavings ?? '0',
+      hbdSavings: a.hbdSavings ?? '0',
+      pendingHive: a.pendingHive ?? '0',
+      pendingHbd: a.pendingHbd ?? '0',
+      pendingHp: a.pendingHp ?? '0',
+      hpDelegatedOut: a.hpDelegatedOut ?? '0',
+      hpDelegatedIn: a.hpDelegatedIn ?? '0',
+      rcPercent: typeof a.rcPercent === 'number' ? a.rcPercent : 0,
+      poweringDown: !!a.poweringDown,
+      powerDownWeeklyHp: a.powerDownWeeklyHp ?? '0',
+    };
   } catch (e: any) {
     return { ok: false, reason: e?.message || 'unavailable' };
   }
@@ -154,6 +211,8 @@ export function getCachedHiveInfo(): HiveAccountInfo | null {
 }
 
 export const HIVE_CAIP = 'hive:beeab0de/slip44:1275';
+// HBD has no SLIP-44; use a stable token caip so it dedups distinctly from HIVE.
+export const HBD_CAIP = 'hive:beeab0de/token:hbd';
 
 /**
  * Synthetic pubkey/asset/balance rows for the read-only UI, built from a
@@ -171,11 +230,14 @@ export function buildHiveUiRows(info: HiveAccountInfo | null) {
     note: 'Hive account',
     symbol: 'HIVE',
   };
+  const priceUsd = info.priceUsd ?? '0';
+  const valueUsd = (parseFloat(info.hive || '0') * parseFloat(priceUsd)).toString();
   const asset = {
     networkId: HIVE_NETWORK_ID,
     caip: HIVE_CAIP,
     name: 'Hive',
     symbol: 'HIVE',
+    priceUsd,
   };
   const balance = {
     networkId: HIVE_NETWORK_ID,
@@ -183,9 +245,37 @@ export function buildHiveUiRows(info: HiveAccountInfo | null) {
     symbol: 'HIVE',
     balance: info.hive,
     isNative: true,
+    priceUsd,
+    valueUsd,
+  };
+  // HBD: receivable to the same account name, but Pioneer has no HBD price, so
+  // show the quantity with USD marked unavailable (never fake the $1 peg).
+  const hbdAsset = { networkId: HIVE_NETWORK_ID, caip: HBD_CAIP, name: 'Hive Backed Dollars', symbol: 'HBD' };
+  const hbdBalance = {
+    networkId: HIVE_NETWORK_ID,
+    caip: HBD_CAIP,
+    symbol: 'HBD',
+    balance: info.hbd,
+    isNative: false,
+    priceUnavailable: true,
     valueUsd: '0',
   };
-  return { pubkey, asset, balance };
+  // Display-only account breakdown for the asset-detail page.
+  const holdings = {
+    hp: info.hp,
+    hbd: info.hbd,
+    hiveSavings: info.hiveSavings,
+    hbdSavings: info.hbdSavings,
+    pendingHive: info.pendingHive,
+    pendingHbd: info.pendingHbd,
+    pendingHp: info.pendingHp,
+    hpDelegatedOut: info.hpDelegatedOut,
+    hpDelegatedIn: info.hpDelegatedIn,
+    rcPercent: info.rcPercent,
+    poweringDown: info.poweringDown,
+    powerDownWeeklyHp: info.powerDownWeeklyHp,
+  };
+  return { pubkey, asset, balance, hbdAsset, hbdBalance, holdings };
 }
 
 /** Build the event object for the side-panel approval flow */

--- a/chrome-extension/src/background/firmware.ts
+++ b/chrome-extension/src/background/firmware.ts
@@ -21,10 +21,19 @@ const REQUIRED = { major: 7, minor: 14, patch: 1 } as const;
 // anything older returns Failure_UnknownMessage for the Hive message types.
 const REQUIRED_HIVE = { major: 7, minor: 15, patch: 0 } as const;
 
-interface FirmwareVersion {
+export interface FirmwareVersion {
   major: number;
   minor: number;
   patch: number;
+}
+
+/**
+ * Cheap, non-probing read of the connected device's firmware version for UI
+ * gating (the add-blockchain picker locks firmware-gated chains). Returns null
+ * if the version isn't known yet — callers should treat null as "not met".
+ */
+export function getCachedFirmwareVersion(): FirmwareVersion | null {
+  return parseVersion(wallet.getDeviceInfo()?.features);
 }
 
 /** Vault REST returns snake_case (see formatFeatures); raw hdwallet uses camelCase. */

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -16,7 +16,8 @@ import { handleSwapMessage, resolveAddress } from './swapHandler';
 import { startSwapEventStream, stopSwapEventStream } from './swapEventStream';
 import { resetTonState, prefetchTonAddress } from './chains/tonHandler';
 import { resetTronState, prefetchTronPubkey } from './chains/tronHandler';
-import { resetHiveState, getHiveAccountInfo, getCachedHiveInfo, buildHiveUiRows } from './chains/hiveHandler';
+import { resetHiveState, getHiveAccountInfo, getCachedHiveInfo, buildHiveUiRows, HBD_CAIP } from './chains/hiveHandler';
+import { getCachedFirmwareVersion } from './firmware';
 
 const HIVE_NETWORK_ID = 'hive:beeab0de';
 import { handleWalletRequest } from './methods';
@@ -1249,6 +1250,12 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
           break;
         }
 
+        case 'GET_FIRMWARE_VERSION': {
+          // Cheap cached read for UI firmware-gating (add-blockchain picker).
+          sendResponse({ version: getCachedFirmwareVersion() });
+          break;
+        }
+
         case 'UPDATE_EVENT_BY_ID': {
           const { id, updatedEvent } = message.payload;
           const success = await requestStorage.updateEventById(id, updatedEvent);
@@ -1422,9 +1429,19 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
                 // an ETH fallback) and the detail page reads a real balance.
                 const hive = buildHiveUiRows(await getHiveAccountInfo());
                 if (hive) {
+                  const isHbd = asset.caip === HBD_CAIP;
+                  const row = isHbd ? hive.hbdBalance : hive.balance;
                   asset.pubkeys = [hive.pubkey];
                   asset.address = hive.pubkey.address;
-                  if (!asset.balance) asset.balance = hive.balance.balance;
+                  if (!asset.balance) asset.balance = row.balance;
+                  // HIVE price is Pioneer-sourced (full CAIP); the synthetic row
+                  // carries it so the detail page shows a real value, not $0.
+                  // (HBD has no Pioneer price — leave it unpriced, never fake $1.)
+                  if (!isHbd && (!asset.priceUsd || asset.priceUsd === '0')) asset.priceUsd = hive.balance.priceUsd;
+                  if (!isHbd && (!asset.valueUsd || asset.valueUsd === '0')) asset.valueUsd = hive.balance.valueUsd;
+                  // Full account breakdown for the asset-detail page (HP, savings,
+                  // rewards, delegation, RC). Display-only.
+                  asset.hiveHoldings = hive.holdings;
                 }
               } else if (asset.networkId) {
                 // An EVM address is identical on every EVM chain, so all
@@ -2120,9 +2137,14 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
           // synthetic row into every response path — the dashboard AND the
           // asset-detail page read from here, so both stay consistent.
           // Non-blocking cached accessor.
-          const hiveBalanceRow = buildHiveUiRows(getCachedHiveInfo())?.balance;
+          const hiveRows = buildHiveUiRows(getCachedHiveInfo());
+          // Inject liquid HIVE and HBD (both vault-sourced). HBD only when held,
+          // so an HBD-less account doesn't get a $0 row.
+          const hiveInject = hiveRows
+            ? [hiveRows.balance, ...(parseFloat(hiveRows.hbdBalance.balance || '0') > 0 ? [hiveRows.hbdBalance] : [])]
+            : [];
           const withHive = (b: any[]) =>
-            hiveBalanceRow ? [...b.filter((x: any) => x.networkId !== HIVE_NETWORK_ID), hiveBalanceRow] : b;
+            hiveInject.length ? [...b.filter((x: any) => x.networkId !== HIVE_NETWORK_ID), ...hiveInject] : b;
           try {
             await portfolioHydrated;
             // Drop a hydrated last-good cache that belongs to a different wallet
@@ -2181,9 +2203,19 @@ chrome.runtime.onMessage.addListener((message: any, sender: any, sendResponse: a
 
         case 'REFRESH_ALL_BALANCES': {
           // Force a fresh Hive fetch too so an explicit refresh updates it.
-          const hiveRefreshed = buildHiveUiRows(await getHiveAccountInfo())?.balance;
+          // Inject HIVE + HBD (when held), same as the passive GET_APP_BALANCES
+          // path — otherwise refresh would drop the HBD row until the next poll.
+          const hiveRefreshedRows = buildHiveUiRows(await getHiveAccountInfo());
+          const hiveRefreshInject = hiveRefreshedRows
+            ? [
+                hiveRefreshedRows.balance,
+                ...(parseFloat(hiveRefreshedRows.hbdBalance.balance || '0') > 0 ? [hiveRefreshedRows.hbdBalance] : []),
+              ]
+            : [];
           const mergeHive = (b: any[]) =>
-            hiveRefreshed ? [...b.filter((x: any) => x.networkId !== HIVE_NETWORK_ID), hiveRefreshed] : b;
+            hiveRefreshInject.length
+              ? [...b.filter((x: any) => x.networkId !== HIVE_NETWORK_ID), ...hiveRefreshInject]
+              : b;
           try {
             if (!wallet.isInitialized()) {
               sendResponse({ balances: mergeHive([]), error: 'Wallet not initialized' });

--- a/packages/shared/lib/utils/chainConfig.ts
+++ b/packages/shared/lib/utils/chainConfig.ts
@@ -96,6 +96,14 @@ export const availableChainsByWallet: Record<string, string[]> = {
   KEEPKEY: Object.values(Chain),
 };
 
+// ---- FIRMWARE_GATED_CHAINS ----
+// Chains that need a minimum KeepKey firmware. The add-blockchain picker shows
+// these as locked (toggle disabled) with the required version when the device
+// is below it. Keyed by networkId (no slip44 suffix). Hive shipped in 7.15.0.
+export const FIRMWARE_GATED_CHAINS: Record<string, { major: number; minor: number; patch: number; label: string }> = {
+  'hive:beeab0de': { major: 7, minor: 15, patch: 0, label: '7.15.0' },
+};
+
 // ---- getChainEnumValue (replaces @pioneer-platform/pioneer-caip's version) ----
 const chainNameToEnum: Record<string, string> = {};
 for (const [key, value] of Object.entries(Chain)) {

--- a/pages/side-panel/src/components/AssetDetail.tsx
+++ b/pages/side-panel/src/components/AssetDetail.tsx
@@ -33,6 +33,27 @@ interface AssetDetailProps {
   onSwap?: () => void;
 }
 
+// Hive account breakdown → label/value rows for the detail page. Zero lines are
+// dropped so a simple account isn't cluttered; HP and RC always show.
+const fmtHive = (v: string, unit: string): string =>
+  `${parseFloat(v || '0').toLocaleString(undefined, { maximumFractionDigits: 3 })} ${unit}`;
+function hiveHoldingRows(hh: any): Array<[string, string]> {
+  const rows: Array<[string, string]> = [['Hive Power', fmtHive(hh.hp, 'HP')]];
+  if (parseFloat(hh.hbd || '0') > 0) rows.push(['HBD', fmtHive(hh.hbd, 'HBD')]);
+  if (parseFloat(hh.hiveSavings || '0') > 0) rows.push(['Savings (HIVE)', fmtHive(hh.hiveSavings, 'HIVE')]);
+  if (parseFloat(hh.hbdSavings || '0') > 0) rows.push(['Savings (HBD)', fmtHive(hh.hbdSavings, 'HBD')]);
+  const pend: string[] = [];
+  if (parseFloat(hh.pendingHive || '0') > 0) pend.push(fmtHive(hh.pendingHive, 'HIVE'));
+  if (parseFloat(hh.pendingHbd || '0') > 0) pend.push(fmtHive(hh.pendingHbd, 'HBD'));
+  if (parseFloat(hh.pendingHp || '0') > 0) pend.push(fmtHive(hh.pendingHp, 'HP'));
+  if (pend.length) rows.push(['Pending rewards', pend.join(' · ')]);
+  if (parseFloat(hh.hpDelegatedOut || '0') > 0) rows.push(['Delegated out', fmtHive(hh.hpDelegatedOut, 'HP')]);
+  if (parseFloat(hh.hpDelegatedIn || '0') > 0) rows.push(['Delegated in', fmtHive(hh.hpDelegatedIn, 'HP')]);
+  rows.push(['Resource Credits', `${Math.round(hh.rcPercent || 0)}%`]);
+  if (hh.poweringDown) rows.push(['Powering down', `${fmtHive(hh.powerDownWeeklyHp, 'HP')} / week`]);
+  return rows;
+}
+
 const AssetDetail = ({ asset, balances, onSend, onReceive, onSwap }: AssetDetailProps) => {
   const [address, setAddress] = useState<string>('');
   const [hasCopied, setHasCopied] = useState(false);
@@ -330,6 +351,30 @@ const AssetDetail = ({ asset, balances, onSend, onReceive, onSwap }: AssetDetail
           </Button>
         )}
       </HStack>
+
+      {/* Hive account breakdown — HP, savings, rewards, delegation, RC. HP is
+          staked HIVE (not a receive target), so it lives here, not in Receive. */}
+      {asset.hiveHoldings && (
+        <Box px={2} pb={2} flexShrink={0}>
+          <Box bg="kk.surface" border="1px solid" borderColor="kk.line" borderRadius="12px" p={3}>
+            <Text className="kk-eyebrow" mb={2}>
+              Hive account
+            </Text>
+            <VStack align="stretch" spacing={1.5}>
+              {hiveHoldingRows(asset.hiveHoldings).map(([label, value], i) => (
+                <Flex key={i} justify="space-between" align="center">
+                  <Text fontSize="xs" color="kk.dim">
+                    {label}
+                  </Text>
+                  <Text fontSize="xs" color="kk.text" className="mono">
+                    {value}
+                  </Text>
+                </Flex>
+              ))}
+            </VStack>
+          </Box>
+        </Box>
+      )}
 
       {/* Tab Bar — Tokens / Activity. flex grows to fill everything below the
           hero so the list reaches the bottom edge (no trailing empty band). */}

--- a/pages/side-panel/src/components/AssetSelect.tsx
+++ b/pages/side-panel/src/components/AssetSelect.tsx
@@ -8,7 +8,16 @@ import {
   NetworkIdToChain,
   COIN_MAP_LONG,
   networkIdToIcon,
+  FIRMWARE_GATED_CHAINS,
 } from '@extension/shared';
+
+type FwVersion = { major: number; minor: number; patch: number };
+const versionMeets = (v: FwVersion | null, min: { major: number; minor: number; patch: number }): boolean => {
+  if (!v) return false;
+  if (v.major !== min.major) return v.major > min.major;
+  if (v.minor !== min.minor) return v.minor > min.minor;
+  return v.patch >= min.patch;
+};
 import { blockchainStorage, blockchainDataStorage } from '@extension/storage';
 
 // Styles for truncating text with ellipsis
@@ -53,12 +62,24 @@ interface AssetSelectProps {
 export function AssetSelect({ setShowAssetSelect }: AssetSelectProps) {
   const [blockchains, setBlockchains] = useState<Chain[]>([]);
   const [walletOptions, setWalletOptions] = useState<string[]>(Object.keys(availableChainsByWallet));
+  const [firmwareVersion, setFirmwareVersion] = useState<FwVersion | null>(null);
   const toast = useToast();
 
   // Effect to load enabled chains on component mount
   useEffect(() => {
     onStart();
+    // Firmware version gates chains like Hive (7.15.0+); null until read.
+    chrome.runtime.sendMessage({ type: 'GET_FIRMWARE_VERSION' }, res => {
+      if (!chrome.runtime.lastError) setFirmwareVersion(res?.version ?? null);
+    });
   }, []);
+
+  // Firmware-gate: locked (can't enable) until the device meets the min version.
+  const chainLock = (networkId: string): { label: string } | null => {
+    const gate = FIRMWARE_GATED_CHAINS[networkId];
+    if (!gate || versionMeets(firmwareVersion, gate)) return null;
+    return { label: gate.label };
+  };
 
   /**
    * Initializes the blockchain data based on the selected wallet.
@@ -122,6 +143,18 @@ export function AssetSelect({ setShowAssetSelect }: AssetSelectProps) {
   const toggleChain = async (networkId: string) => {
     const chain = blockchains.find(c => c.networkId === networkId);
     if (!chain) return;
+
+    const lock = chainLock(networkId);
+    if (lock) {
+      toast({
+        title: `${chain.name} requires firmware ${lock.label}`,
+        description: 'Update your KeepKey in the KeepKey Vault desktop app to enable it.',
+        status: 'info',
+        duration: 4000,
+        isClosable: true,
+      });
+      return;
+    }
 
     const isCurrentlyEnabled = chain.isEnabled;
 
@@ -187,9 +220,8 @@ export function AssetSelect({ setShowAssetSelect }: AssetSelectProps) {
   const selectAllChains = async () => {
     const tag = ' | selectAllChains | ';
     try {
-      // Enable all chains in storage
-
-      const allnetworkIds = blockchains.map(chain => chain.networkId);
+      // Enable all chains in storage (skip firmware-locked ones like Hive).
+      const allnetworkIds = blockchains.map(chain => chain.networkId).filter(id => !chainLock(id));
       await blockchainStorage.addBlockchains(allnetworkIds);
       console.log(tag, 'All chains added to storage:', allnetworkIds);
 
@@ -313,28 +345,42 @@ export function AssetSelect({ setShowAssetSelect }: AssetSelectProps) {
    * Renders a single blockchain item with its details and toggle switch.
    * @param chain - The blockchain data to render.
    */
-  const renderChain = (chain: Chain) => (
-    <Flex
-      key={chain.networkId}
-      alignItems="center"
-      justifyContent="space-between"
-      p={2}
-      borderBottomWidth="1px"
-      borderColor="gray.200">
-      <Flex alignItems="center">
-        <AssetIcon src={chain.image} symbol={chain.name} size={32} style={{ marginRight: 16 }} />
-        <Text fontWeight="bold">{chain.name}</Text>
+  const renderChain = (chain: Chain) => {
+    const lock = chainLock(chain.networkId);
+    return (
+      <Flex
+        key={chain.networkId}
+        alignItems="center"
+        justifyContent="space-between"
+        p={2}
+        borderBottomWidth="1px"
+        borderColor="gray.200"
+        opacity={lock ? 0.6 : 1}>
+        <Flex alignItems="center">
+          <AssetIcon src={chain.image} symbol={chain.name} size={32} style={{ marginRight: 16 }} />
+          <Text fontWeight="bold">{chain.name}</Text>
+        </Flex>
+        <Flex alignItems="center">
+          {lock ? (
+            <Badge mr={4} colorScheme="yellow" title={`Requires KeepKey firmware ${lock.label}`}>
+              <Text fontSize="xs">🔒 firmware {lock.label}+</Text>
+            </Badge>
+          ) : (
+            <Badge mr={4}>
+              <Text fontSize="xs" style={middleEllipsisStyle}>
+                {chain.networkId}
+              </Text>
+            </Badge>
+          )}
+          <Switch
+            isChecked={chain.isEnabled && !lock}
+            isDisabled={!!lock}
+            onChange={() => toggleChain(chain.networkId)}
+          />
+        </Flex>
       </Flex>
-      <Flex alignItems="center">
-        <Badge mr={4}>
-          <Text fontSize="xs" style={middleEllipsisStyle}>
-            {chain.networkId}
-          </Text>
-        </Badge>
-        <Switch isChecked={chain.isEnabled} onChange={() => toggleChain(chain.networkId)} />
-      </Flex>
-    </Flex>
-  );
+    );
+  };
 
   // Group and sort chains by type
   const { UTXO, EVM, others } = blockchains.reduce(


### PR DESCRIPTION
The client fetched the whole Hive account from Pioneer but showed only liquid HIVE at **$0.00**. This surfaces the rest and gates it correctly by firmware. Client-only; the vault fix it depends on is captured as a handoff (see below).

## What

### 1. Price the synthetic Hive balance
`buildHiveUiRows` hardcoded `valueUsd: '0'`. Now it fetches the HIVE price via Pioneer `POST /api/v1/market/info` with the **full CAIP** `hive:beeab0de/slip44:1275` — the networkId and `HIVE` ticker both return 0 (Pioneer's map is keyed by CAIP-19). Sets `priceUsd` + `valueUsd` on the balance/asset rows and the asset context. Dashboard + detail now show a real value (26 HIVE ≈ $1.25).

### 2. HBD receivable
Emits a second synthetic balance row (`hive:beeab0de/token:hbd`), so HBD appears in the Receive dropdown and resolves to the same account-name address. **Pioneer has no HBD price**, so HBD shows its quantity with USD marked unavailable — the $1 peg is *not* faked. HBD shares the Hive networkId, so the dashboard's native filter keeps it out of the HIVE row amount/total (no duplicate row, no double-count). Both merge paths (`GET_APP_BALANCES` and `REFRESH_ALL_BALANCES`) inject HIVE + HBD when held.

### 3. Full account holdings on the detail page
`HiveAccountInfo` now carries HP, savings (HIVE/HBD), pending rewards, delegation in/out, RC%, and power-down state. `SET_ASSET_CONTEXT` attaches them as `asset.hiveHoldings`; `AssetDetail` renders a **"Hive account"** breakdown card (zero lines hidden). HP is staked — not a receive target — so it lives on detail, not Receive.

### 4. Firmware-gate the Add-blockchains entry
Hive was already in the picker with a dead toggle. Now it's locked with a **🔒 firmware 7.15.0+** badge until the device meets it, via a new `GET_FIRMWARE_VERSION` message + `FIRMWARE_GATED_CHAINS` map. Auto-unlocks on firmware update; "Select All" skips locked chains.

## Depends on (vault)
`HANDOFF_vault_hive_addresses_500.md` — the vault's `/addresses/hive` currently 500s with `json is not defined` (a `requireChainSupport` lexical-scope bug) on sub-7.15.0 firmware instead of a clean 501. Client is correct; that's the vault-side fix.

## Test
`make type-check` 15/15 · `make test` 111/111 · `make build` 9/9. Reviewed with a 3-dimension adversarial pass (1 finding — `REFRESH_ALL_BALANCES` dropped the HBD row — found and fixed).

## Known gap
HBD shows USD-unavailable until Pioneer adds HBD to its market map (keyed by `token:hbd`). No fake value in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)