### PR TITLE
fix(hive): use hivehub.dev for transaction explorer links

### DIFF
--- a/chrome-extension/src/background/chains/hiveHandler.ts
+++ b/chrome-extension/src/background/chains/hiveHandler.ts
@@ -464,7 +464,7 @@ async function hiveTransfer(
       action: 'transaction_complete',
       eventId: requestInfo.id,
       txHash: bData.txid,
-      explorerTxLink: 'https://hiveblocks.com/tx/',
+      explorerTxLink: 'https://hivehub.dev/tx/',
       networkId: HIVE_NETWORK_ID,
     })
     .catch(() => {});
@@ -745,7 +745,7 @@ async function hiveSignAndBroadcastOps(
       action: 'transaction_complete',
       eventId: requestInfo.id,
       txHash: bData.txid,
-      explorerTxLink: 'https://hiveblocks.com/tx/',
+      explorerTxLink: 'https://hivehub.dev/tx/',
       networkId: HIVE_NETWORK_ID,
     })
     .catch(() => {});


### PR DESCRIPTION
Swap the Hive transaction explorer from hiveblocks.com to hivehub.dev.

Both `explorerTxLink` occurrences in `hiveHandler.ts` now point at
`https://hivehub.dev/tx/` (e.g. https://hivehub.dev/tx/0cc1868cd9d487ffe14bb94f1b8af0f1925997f1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)