### PR TITLE
feat(bex): every page-touching MCP tool shows UI in the page

### DIFF
--- a/chrome-extension/src/background/announceContract.test.ts
+++ b/chrome-extension/src/background/announceContract.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The transparency contract, enforced.
+ *
+ * Rule: if an MCP tool touches a web page, that page shows the user it is
+ * happening. The overlay used to fire only from showThen() (click/type/select),
+ * so every read — snapshot, read_page, console, network, storage, screenshot —
+ * ran invisibly. That is the class of bug this file exists to prevent coming
+ * back.
+ *
+ * A new browser tool must land in ANNOUNCE_CAPTIONS or NO_ANNOUNCE. There is no
+ * third option and no default, so "I forgot the overlay" fails the build
+ * instead of shipping a silent tool.
+ */
+import { describe, it, expect } from 'vitest';
+import { BROWSER_TOOLS, ANNOUNCE_CAPTIONS, NO_ANNOUNCE } from './browserTools';
+
+const toolNames = () => BROWSER_TOOLS.map(t => t.name);
+
+describe('MCP transparency contract', () => {
+  it('classifies every browser tool as announced or explicitly exempt', () => {
+    const unclassified = toolNames().filter(n => !(n in ANNOUNCE_CAPTIONS) && !(n in NO_ANNOUNCE));
+    expect(
+      unclassified,
+      `Unclassified browser tool(s): ${unclassified.join(', ')}. ` +
+        'Every tool must either announce itself in the page (add a caption to ' +
+        'ANNOUNCE_CAPTIONS) or state why it need not (add it to NO_ANNOUNCE). ' +
+        'If it reads or captures page content, it announces.',
+    ).toEqual([]);
+  });
+
+  it('never classifies a tool as both', () => {
+    const both = toolNames().filter(n => n in ANNOUNCE_CAPTIONS && n in NO_ANNOUNCE);
+    expect(both).toEqual([]);
+  });
+
+  it('does not classify tools that no longer exist', () => {
+    const known = new Set(toolNames());
+    const stale = [...Object.keys(ANNOUNCE_CAPTIONS), ...Object.keys(NO_ANNOUNCE)].filter(n => !known.has(n));
+    expect(stale, `Stale entries for removed tool(s): ${stale.join(', ')}`).toEqual([]);
+  });
+
+  it('announces every tool that reads or captures page content', () => {
+    // Pinned by name on purpose. These are the operations a user cannot
+    // otherwise perceive, so moving one into NO_ANNOUNCE has to be a deliberate
+    // edit to this list with a reviewer looking at it.
+    const mustAnnounce = [
+      'bex_snapshot',
+      'bex_find',
+      'bex_read_page',
+      'bex_console',
+      'bex_network',
+      'bex_perf',
+      'bex_storage',
+      'bex_screenshot',
+    ];
+    for (const name of mustAnnounce) {
+      expect(ANNOUNCE_CAPTIONS[name], `${name} reads page content and must announce`).toBeTruthy();
+    }
+  });
+
+  it('gives every exemption a stated reason', () => {
+    for (const [name, reason] of Object.entries(NO_ANNOUNCE)) {
+      expect(reason.length, `${name} is exempt without saying why`).toBeGreaterThan(10);
+    }
+  });
+});

--- a/chrome-extension/src/background/browserTools.ts
+++ b/chrome-extension/src/background/browserTools.ts
@@ -365,9 +365,13 @@ async function screenshot(tab: chrome.tabs.Tab, quality: number): Promise<Conten
   // Chrome can only capture the ACTIVE tab of a window, so focus it first. This
   // is a visible side effect and is called out in the tool description.
   if (!tab.active && tab.id != null) await chrome.tabs.update(tab.id, { active: true });
-  // Hide the agent overlay so it doesn't land in the capture; best-effort (the
-  // page may have no content script). It resolves after a painted frame.
-  if (tab.id != null) await dom(tab.id, 'overlay', { show: false }).catch(() => {});
+  // Hide the agent overlay so it doesn't land in the capture. This is also the
+  // transparency check: reaching the content script is what proves the tab CAN
+  // show the driving indicator. It cannot, we don't capture — a silent
+  // screenshot of a page the user has no indication we are reading is exactly
+  // what the contract forbids. (dom() throws no_content_script here; the
+  // remedy is the same page reload it already tells the user about.)
+  if (tab.id != null) await dom(tab.id, 'overlay', { show: false });
   let dataUrl: string;
   try {
     dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId!, { format: 'jpeg', quality });
@@ -397,7 +401,53 @@ export function isBrowserTool(name: string): boolean {
   return BROWSER_TOOLS.some(t => t.name === name);
 }
 
+/**
+ * The transparency contract: if MCP touches a page, the page says so.
+ *
+ * Caption shown in the page overlay before the tool runs. Every browser tool
+ * must appear HERE or in NO_ANNOUNCE — announceContract.test.ts fails the build
+ * otherwise, so a tool added later cannot silently become invisible.
+ */
+export const ANNOUNCE_CAPTIONS: Record<string, string> = {
+  bex_snapshot: 'reading page structure',
+  bex_find: 'searching page',
+  bex_read_page: 'reading page text',
+  bex_console: 'reading console',
+  bex_network: 'reading network activity',
+  bex_perf: 'reading performance data',
+  bex_storage: 'reading local storage',
+  bex_screenshot: 'capturing screenshot',
+};
+
+/** Tools that need no announce, each with the reason it is exempt. */
+export const NO_ANNOUNCE: Record<string, string> = {
+  bex_panel: 'is the transparency UI itself',
+  bex_tabs: 'browser-level; touches no page content',
+  bex_navigate: 'self-evident — the user watches their tab move',
+  bex_bring_to_front: 'self-evident — the user watches their window raise',
+  bex_click: 'announced page-side by showThen(), which also points at the target',
+  bex_type: 'announced page-side by showThen(), which also points at the target',
+  bex_select: 'announced page-side by showThen(), which also points at the target',
+};
+
+/**
+ * Raise the page overlay before a tool runs. Never throws: a tab that cannot
+ * show the indicator is handled by each tool (bex_screenshot refuses), not by
+ * failing every read here.
+ */
+async function announce(tool: string, args: any): Promise<void> {
+  const caption = ANNOUNCE_CAPTIONS[tool];
+  if (!caption) return;
+  try {
+    const tab = await resolveTab(args?.tabId);
+    if (tab.id != null) await dom(tab.id, 'announce', { kind: caption });
+  } catch {
+    /* no content script, or the tab vanished — never block the tool on the UI */
+  }
+}
+
 export async function executeBrowserTool(tool: string, args: any): Promise<any> {
+  await announce(tool, args);
   switch (tool) {
     case 'bex_tabs': {
       const action = args?.action ?? 'list';

--- a/pages/content/src/agentDom.ts
+++ b/pages/content/src/agentDom.ts
@@ -21,7 +21,7 @@
 
 import { getPageConsole } from './consoleBridge';
 import { pullObs } from './obsBridge';
-import { overlayAct, overlaySetVisible } from './agentOverlay';
+import { overlayAct, overlayAnnounce, overlayEndSession, overlaySetVisible } from './agentOverlay';
 import { panelShow, panelHide, panelLog, panelStatus } from './agentPanel';
 
 const TAG = ' | agentDom | ';
@@ -450,13 +450,25 @@ async function handle(msg: any): Promise<any> {
       await overlaySetVisible(msg.show !== false);
       return { overlay: msg.show !== false };
 
+    // The transparency floor: the background announces every page-touching tool
+    // here BEFORE running it, so reads and captures are as visible as clicks.
+    case 'announce':
+      overlayAnnounce(String(msg.kind ?? 'working'), String(msg.detail ?? ''));
+      panelLog(msg.detail ? `${msg.kind}: ${msg.detail}` : String(msg.kind ?? 'working'));
+      return { announced: msg.kind ?? 'working' };
+
     case 'panel': {
       if (msg.action === 'hide') {
+        overlayEndSession();
         panelHide();
         return { panel: 'hidden' };
       }
-      if (msg.message != null || msg.level) panelStatus(String(msg.message ?? ''), msg.level ?? 'info');
-      else panelShow();
+      if (msg.message != null || msg.level) {
+        panelStatus(String(msg.message ?? ''), msg.level ?? 'info');
+        // 'done' is the agent saying it has stopped driving — drop the banner
+        // now rather than leaving it up until the safety timer expires.
+        if (msg.level === 'done') overlayEndSession();
+      } else panelShow();
       return { panel: 'shown' };
     }
 

--- a/pages/content/src/agentOverlay.ts
+++ b/pages/content/src/agentOverlay.ts
@@ -15,7 +15,17 @@
 const ROOT_ID = '__bex_agent_overlay';
 const Z = 2147483647; // max z-index — sit above everything the page draws
 const HIGHLIGHT_MS = 1100; // how long the box + label linger after an action
-const BANNER_IDLE_MS = 8000; // hide the "driving" banner after this much quiet
+/**
+ * Safety net only — NOT the normal way the banner goes away.
+ *
+ * The banner must stay up for the whole driving session: a hardware-wallet
+ * confirmation routinely leaves the tab quiet for far longer than a few
+ * seconds, and that silence is exactly when the user most needs to see that an
+ * agent is in control. It is cleared explicitly by overlayEndSession() (the
+ * panel's 'done'/hide). This timer only covers an agent that dies mid-session
+ * and never sends one.
+ */
+const BANNER_IDLE_MS = 300_000;
 const GOLD = '#d29929'; // brand token
 
 let root: HTMLElement | null = null;
@@ -113,6 +123,47 @@ function showBanner(): void {
     if (banner) banner.style.display = 'none';
     if (cursor) cursor.style.opacity = '0';
   }, BANNER_IDLE_MS);
+}
+
+/**
+ * Announce a page-touching action that has no target element to point at —
+ * reading the DOM, capturing a screenshot, pulling console/network/storage.
+ *
+ * These are the operations a user cannot otherwise perceive at all, so this is
+ * the floor of the transparency contract: the banner goes up and the caption
+ * names what is being done. overlayAct() is the richer treatment for actions
+ * that DO have a target.
+ *
+ * Best-effort, never throws — a broken overlay must not break a wallet action.
+ */
+export function overlayAnnounce(kind: string, detail = ''): void {
+  try {
+    if (!ensureRoot() || !label) return;
+    showBanner();
+    // Park the caption top-left, under the banner: there is no element to anchor
+    // it to, and it must not imply one.
+    Object.assign(label.style, { left: '8px', top: '34px', opacity: '1' });
+    label.textContent = detail ? `${kind}: ${detail}` : kind;
+    clearTimeout(fadeTimer);
+    fadeTimer = setTimeout(() => {
+      if (label) label.style.opacity = '0';
+    }, HIGHLIGHT_MS);
+  } catch {
+    /* overlay must never break an action */
+  }
+}
+
+/** The agent is done driving: drop the banner instead of waiting out the safety timer. */
+export function overlayEndSession(): void {
+  try {
+    clearTimeout(bannerTimer);
+    if (banner) banner.style.display = 'none';
+    if (cursor) cursor.style.opacity = '0';
+    if (box) box.style.opacity = '0';
+    if (label) label.style.opacity = '0';
+  } catch {
+    /* ignore */
+  }
 }
 
 /** Point at + outline `target` and caption the action. Best-effort, never throws. */


### PR DESCRIPTION
## The rule

> Any MCP operation that touches a web page must be visible in that page, every time, without the agent having to remember to announce it.

## What was broken

The overlay (`pages/content/src/agentOverlay.ts` — animated pointer, target outline, `🤖 MCP is driving this tab` banner) fired only from `showThen()`, which has exactly three callers (`agentDom.ts:399,406,425`): click, type, select.

Everything else touched pages silently:

| tool | what it did with no indication |
|---|---|
| `bex_snapshot`, `bex_find` | read the DOM |
| `bex_read_page` | read page text |
| `bex_console`, `bex_network`, `bex_perf` | read page state |
| `bex_storage` | read localStorage |
| `bex_screenshot` | captured the tab |

Reading and capturing a user's page are exactly the operations that most need to be visible. This surfaced in a live session where the user watched a tab expecting the driving UI and correctly saw nothing — the session had only navigated, snapshotted and read.

## The change

**Enforced at the dispatcher, not per call site.** `executeBrowserTool()` (`browserTools.ts:400`) is the single switch over every `bex_*` tool, so it announces once, before the switch. A tool added later is covered by construction.

Every tool is either in `ANNOUNCE_CAPTIONS` (caption shown in-page) or `NO_ANNOUNCE` (with a stated reason). Exemptions:

- `bex_panel` — is the transparency UI itself
- `bex_tabs` — browser-level, touches no page content
- `bex_navigate`, `bex_bring_to_front` — self-evident; the user watches their own tab move
- `bex_click`, `bex_type`, `bex_select` — already announced page-side by `showThen()`, which additionally points at the target

`announce()` never throws — a tab that cannot show the indicator is each tool's decision, not a reason to fail every read.

**`bex_screenshot` is now strict.** It already had to reach the content script to hide the overlay out of the capture; that same round trip is what proves the tab *can* show the indicator. The `.catch(() => {})` is gone, so a capture that cannot be announced is not taken. Remedy is the page reload `no_content_script` already names.

**Banner lifetime.** `BANNER_IDLE_MS` was 8s, so the banner vanished during any quiet stretch — including while waiting on a hardware-wallet confirmation, the longest silence and highest stakes in the flow. It now persists until the agent signals done (`bex_panel` `level: 'done'`, or hide), with a 5 minute safety net for an agent that dies mid-session.

## No new permissions

The overlay is plain DOM in the content script already declaratively injected on `<all_urls>` at `document_start`. The `scripting` permission dropped in `b3e3126` was only ever for `chrome.scripting.executeScript` into tabs predating extension load — unrelated to the UI. **Nothing here reopens a Web Store permission re-review.**

## Tests

`npx vitest run` in `chrome-extension/` — **116 pass, 10 files**, up from 111.

`announceContract.test.ts` is the guard that keeps this from rotting: it enumerates `BROWSER_TOOLS` and fails on any tool in neither bucket, in both, or referring to a tool that no longer exists, and pins the read/capture set by name so moving one out of announcing takes a deliberate, reviewable edit.

Differential-verified — deleting the `bex_storage` caption fails the build with:

```
Unclassified browser tool(s): bex_storage. Every tool must either announce
itself in the page (add a caption to ANNOUNCE_CAPTIONS) or state why it need
not (add it to NO_ANNOUNCE). If it reads or captures page content, it announces.
```

`tsc --noEmit` clean for both `chrome-extension` and `pages/content`.

## Reviewer note

The behaviour break is `bex_screenshot` on a tab with no content script: previously it captured, now it errors. That is intentional and was the explicitly chosen option — a screenshot the user has no indication of is what the contract forbids.